### PR TITLE
Update basic example in README to reflect that GetFileJson() takes a path to a file, not a URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func main() {
 
 	jsonToValidate, err := gojsonschema.GetHttpJson("http://myotherhost/blu/extract56.json")
 	// OR
-	//jsonToValidate, err := gojsonschema.GetFileJson("file:///home/billy/hotels.json")
+	//jsonToValidate, err := gojsonschema.GetFileJson("/home/billy/hotels.json")
 	
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
The example in the README shows GetFileJson() being called on a URI (albeit a file:/// one).  When I tried this, I got a panic:

`panic: open file://...: no such file or directory`

GetFileJson() actually just takes a path to a file.  This pull request updates the example to reflect that.
