### PR TITLE
Parse individual definition values as subschemas

### DIFF
--- a/schemaDocument.go
+++ b/schemaDocument.go
@@ -171,7 +171,7 @@ func (d *JsonSchemaDocument) parseSchema(documentNode interface{}, currentSchema
 				if isKind(dv, reflect.Map) {
 					newSchema := &jsonSchema{property: KEY_DEFINITIONS, parent: currentSchema, ref: currentSchema.ref}
 					currentSchema.definitions[dk] = newSchema
-					err := d.parseSchema(m[KEY_DEFINITIONS], newSchema)
+					err := d.parseSchema(dv, newSchema)
 					if err != nil {
 						return errors.New(err.Error())
 					}


### PR DESCRIPTION
I noticed something which I think is a bug around gojsonschema's handling of subschemas defined within `definitions` hashes.

A simple reproduction:

``` go
package main

import (
    "github.com/sigu-399/gojsonschema"
)

func main() {
    _, err := gojsonschema.NewJsonSchemaDocument("file://./schema.json")
    if err != nil {
        panic(err.Error())
    }
}
```

``` json
{
    "definitions": {
        "description": {
            "description": "A subschema named description."
         }
    }
}
```

Output:

``` ./gojsonschema-repro
panic: description must be of type string

goroutine 1 [running]:
runtime.panic(0x1f3e20, 0xc21000a730)
        /usr/local/go/src/pkg/runtime/panic.c:266 +0xb6
main.main()
        /Users/brandur/Documents/go/src/github.com/brandur/gojsonschema-repro/main.go:10 +0xa8
```

It appears that gojsonschema is actually trying to parse the subobject under `definitions` as a subschema when I think what it should be doing is parsing every subobject under a key in the `definitions` key as a subschema (and thus a definition named `description` is not allowed because that's expected to be a string in a schema).

The change on this pull request seems to fix the problem for me and furthermore allows my large non-trivial schema to be fully parsed as well. That said, there may be something at work here that I'm not quite understanding. Thoughts?
