### PR TITLE
fix large integers not valid

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	"strconv"
 )
 
 func isKind(what interface{}, kind reflect.Kind) bool {
@@ -54,24 +53,14 @@ func isStringInSlice(s []string, what string) bool {
 // Practical when it comes to differentiate a float from an integer since JSON only knows numbers
 // NOTE go's Parse(U)Int funcs accepts 1.0, 45.0 as integers
 func isFloat64AnInteger(n float64) bool {
-	_, errInt := strconv.ParseInt(fmt.Sprintf("%v", n), 10, 64)
-	_, errUint := strconv.ParseUint(fmt.Sprintf("%v", n), 10, 64)
-	return errInt == nil || errUint == nil
+	return n == float64(int64(n)) || n == float64(uint64(n))
 }
 
 // formats a number so that it is displayed as the smallest string possible
 func validationErrorFormatNumber(n float64) string {
 
 	if isFloat64AnInteger(n) {
-
-		valInt, errInt := strconv.ParseInt(fmt.Sprintf("%v", n), 10, 64)
-		valUint, errUint := strconv.ParseUint(fmt.Sprintf("%v", n), 10, 64)
-
-		if errInt == nil {
-			return fmt.Sprintf("%v", valInt)
-		} else if errUint == nil {
-			return fmt.Sprintf("%v", valUint)
-		}
+		return fmt.Sprintf("%d", int64(n))
 	}
 
 	return fmt.Sprintf("%g", n)

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,75 @@
+package gojsonschema
+
+import (
+	"github.com/stretchr/testify/assert"
+	"math"
+	"testing"
+)
+
+func TestIsFloat64Integer(t *testing.T) {
+	// fails. MaxUint64 is to large for JS anyway, so we can ignore it here.
+	//assert.True(t, isFloat64AnInteger(float64(math.MaxUint64)))
+
+	assert.True(t, isFloat64AnInteger(math.MaxInt64))
+	assert.True(t, isFloat64AnInteger(1<<62))
+	assert.True(t, isFloat64AnInteger(math.MinInt64))
+	assert.True(t, isFloat64AnInteger(100100100100))
+	assert.True(t, isFloat64AnInteger(-100100100100))
+	assert.True(t, isFloat64AnInteger(100100100))
+	assert.True(t, isFloat64AnInteger(-100100100))
+	assert.True(t, isFloat64AnInteger(100100))
+	assert.True(t, isFloat64AnInteger(-100100))
+	assert.True(t, isFloat64AnInteger(100))
+	assert.True(t, isFloat64AnInteger(-100))
+	assert.True(t, isFloat64AnInteger(-0))
+	assert.True(t, isFloat64AnInteger(-1))
+	assert.True(t, isFloat64AnInteger(1))
+	assert.True(t, isFloat64AnInteger(0))
+	assert.True(t, isFloat64AnInteger(77))
+	assert.True(t, isFloat64AnInteger(-77))
+	assert.True(t, isFloat64AnInteger(1e10))
+	assert.True(t, isFloat64AnInteger(-1e10))
+	assert.True(t, isFloat64AnInteger(100100100.0))
+	assert.True(t, isFloat64AnInteger(-100100100.0))
+
+	assert.False(t, isFloat64AnInteger(100100100100.1))
+	assert.False(t, isFloat64AnInteger(-100100100100.1))
+	assert.False(t, isFloat64AnInteger(math.MaxFloat64))
+	assert.False(t, isFloat64AnInteger(-math.MaxFloat64))
+	assert.False(t, isFloat64AnInteger(1.1))
+	assert.False(t, isFloat64AnInteger(-1.1))
+	assert.False(t, isFloat64AnInteger(1.000000000001))
+	assert.False(t, isFloat64AnInteger(-1.000000000001))
+	assert.False(t, isFloat64AnInteger(1e-10))
+	assert.False(t, isFloat64AnInteger(-1e-10))
+}
+
+func TestValidationErrorFormatNumber(t *testing.T) {
+	assert.Equal(t, "1", validationErrorFormatNumber(1))
+	assert.Equal(t, "-1", validationErrorFormatNumber(-1))
+	assert.Equal(t, "0", validationErrorFormatNumber(0))
+	// unfortunately, can not be recognized as float
+	assert.Equal(t, "0", validationErrorFormatNumber(0.0))
+
+	assert.Equal(t, "1.001", validationErrorFormatNumber(1.001))
+	assert.Equal(t, "-1.001", validationErrorFormatNumber(-1.001))
+	assert.Equal(t, "0.0001", validationErrorFormatNumber(0.0001))
+
+	// casting math.MaxInt64 (1<<63 -1) to float back to int64
+	// becomes negative. obviousely because of bit missinterpretation.
+	// so simply test a slightly smaller "large" integer here
+	assert.Equal(t, "4611686018427387904", validationErrorFormatNumber(1<<62))
+	// with negative int64 max works
+	assert.Equal(t, "-9223372036854775808", validationErrorFormatNumber(math.MinInt64))
+	assert.Equal(t, "-4611686018427387904", validationErrorFormatNumber(-1<<62))
+
+	assert.Equal(t, "10000000000", validationErrorFormatNumber(1e10))
+	assert.Equal(t, "-10000000000", validationErrorFormatNumber(-1e10))
+
+	assert.Equal(t, "1.000000000001", validationErrorFormatNumber(1.000000000001))
+	assert.Equal(t, "-1.000000000001", validationErrorFormatNumber(-1.000000000001))
+	assert.Equal(t, "1e-10", validationErrorFormatNumber(1e-10))
+	assert.Equal(t, "-1e-10", validationErrorFormatNumber(-1e-10))
+	assert.Equal(t, "4.6116860184273876e+07", validationErrorFormatNumber(4.611686018427387904e7))
+	assert.Equal(t, "-4.6116860184273876e+07", validationErrorFormatNumber(-4.611686018427387904e7))
+}


### PR DESCRIPTION
issue was: large ints in json are not valid json schema `"type":"interger"`
because `fmt.Sprintf("%v")` formats large int in exponential expression. e.g.
`100100100100 -> "1.001001e+11"`
Refactored to use type casting instead of `Sprintf + ParseInt`.

`validationErrorFormatNumber` mangled large integers in the same way. e.g. this is not wanted when you have DB IDs as integer in json.
