### PR TITLE
Constrain integers to [-2^53 -1, 2^53-1]

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -51,9 +51,10 @@ func isStringInSlice(s []string, what string) bool {
 	return false
 }
 
+// same as ECMA Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
 const (
-	max_json_float = float64(1<<53 - 1) // 9007199254740991.0 	 2^53 - 1
-	min_json_float = -float64(1 << 53)  //-9007199254740992.0	-2^53
+	max_json_float = float64(1<<53 - 1) // 9007199254740991.0 	 	 2^53 - 1
+	min_json_float = -float64(1 << 53 - 1)  //-9007199254740991.0	-2^53 - 1
 )
 
 // allow for integers [-2^53, 2^53-1] inclusive

--- a/utils_test.go
+++ b/utils_test.go
@@ -28,7 +28,7 @@ func TestIsFloat64IntegerA(t *testing.T) {
 	assert.True(t, isFloat64AnInteger(-float64(1<<53-1)))
 	assert.True(t, isFloat64AnInteger(float64(1<<53-1)))
 	assert.False(t, isFloat64AnInteger(float64(1<<53)))
-	assert.True(t, isFloat64AnInteger(-float64(1<<53)))
+	assert.False(t, isFloat64AnInteger(-float64(1<<53)))
 	assert.False(t, isFloat64AnInteger(float64(1<<63)))
 	assert.False(t, isFloat64AnInteger(-float64(1<<63)))
 	assert.False(t, isFloat64AnInteger(math.Nextafter(float64(1<<63), math.MaxFloat64)))
@@ -39,8 +39,8 @@ func TestIsFloat64IntegerA(t *testing.T) {
 	assert.False(t, isFloat64AnInteger(math.Nextafter(float64(9007199254740991.0), math.MaxFloat64)))
 	assert.True(t, isFloat64AnInteger(float64(9007199254740991.0)))
 
-	assert.True(t, isFloat64AnInteger(float64(-9007199254740992.0)))
-	assert.False(t, isFloat64AnInteger(math.Nextafter(float64(-9007199254740992.0), -math.MaxFloat64)))
+	assert.True(t, isFloat64AnInteger(float64(-9007199254740991.0)))
+	assert.False(t, isFloat64AnInteger(math.Nextafter(float64(-9007199254740991.0), -math.MaxFloat64)))
 }
 
 func TestIsFloat64Integer(t *testing.T) {


### PR DESCRIPTION
Constrains integers to the continuous range and matches ECMA Script Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER 
