### PR TITLE
Enhance error context and support for custom locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Dependencies :
 * [github.com/xeipuuv/gojsonreference](https://github.com/xeipuuv/gojsonreference)
 * [github.com/stretchr/testify/assert](https://github.com/stretchr/testify#assert-package)
 
-## Usage 
+## Usage
 
 ### Example
 
@@ -63,7 +63,7 @@ func main() {
 #### Loaders
 
 There are various ways to load your JSON data.
-In order to load your schemas and documents, 
+In order to load your schemas and documents,
 first declare an appropriate loader :
 
 * Web / HTTP, using a reference :
@@ -141,12 +141,66 @@ To check the result :
     	fmt.Printf("The document is valid\n")
     } else {
         fmt.Printf("The document is not valid. see errors :\n")
-        for _, desc := range result.Errors() {
-            fmt.Printf("- %s\n", desc)
+        for _, err := range result.Errors() {
+        	// Err implements the ResultError interface
+            fmt.Printf("- %s\n", err)
         }
     }
 ```
 
+## Working with Errors
+
+The library handles string error codes which you can customize by creating your own gojsonschema.locale and setting it
+```go
+gojsonschema.Locale = YourCustomLocale{}
+```
+
+However, each error contains additional contextual information.
+
+**err.Type()**: *string* Returns the "type" of error that occurred. Note you can also type check. See below
+
+Note: An error of RequiredType has an err.Type() return value of "required"
+
+    "required": RequiredError
+    "invalid_type": InvalidTypeError
+    "number_any_of": NumberAnyOfError
+    "number_one_of": NumberOneOfError
+    "number_all_of": NumberAllOfError
+    "number_not": NumberNotError
+    "missing_dependency": MissingDependencyError
+    "internal": InternalError
+    "enum": EnumError
+    "array_no_additional_items": ArrayNoAdditionalItemsError
+    "array_min_items": ArrayMinItemsError
+    "array_max_items": ArrayMaxItemsError
+    "unique": ItemsMustBeUniqueError
+    "array_min_properties": ArrayMinPropertiesError
+    "array_max_properties": ArrayMaxPropertiesError
+    "additional_property_not_allowed": AdditionalPropertyNotAllowedError
+    "invalid_property_pattern": InvalidPropertyPatternError
+    "string_gte": StringLengthGTEError
+    "string_lte": StringLengthLTEError
+    "pattern": DoesNotMatchPatternError
+    "multiple_of": MultipleOfError
+    "number_gte": NumberGTEError
+    "number_gt": NumberGTError
+    "number_lte": NumberLTEError
+    "number_lt": NumberLTError
+
+**err.Value()**: *interface{}* Returns the value given
+
+**err.Context()**: *gojsonschema.jsonContext* Returns the context. This has a String() method that will print something like this: (root).firstName
+
+**err.Field()**: *string* Returns the fieldname in the format firstName, or for embedded properties, person.firstName. This returns the same as the String() method on *err.Context()* but removes the (root). prefix.
+
+**err.Description()**: *string* The error description. This is based on the locale you are using. See the beginning of this section for overwriting the locale with a custom implementation.
+
+**err.Details()**: *gojsonschema.ErrorDetails* Returns a map[string]interface{} of additional error details specific to the error. For example, GTE errors will have a "min" value, LTE will have a "max" value. See errors.go for a full description of all the error details. Every error always contains a "field" key that holds the value of *err.Field()*
+
+Note in most cases, the err.Details() will be used to generate replacement strings in your locales. and not used directly i.e.
+```
+%field% must be greater than or equal to %min%
+```
 ## Uses
 
 gojsonschema uses the following test suite :

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,234 @@
+package gojsonschema
+
+import (
+	"fmt"
+	"strings"
+)
+
+type (
+	// RequiredError. ErrorDetails: property string
+	RequiredError struct {
+		ResultErrorFields
+	}
+
+	// InvalidTypeError. ErrorDetails: expected, given
+	InvalidTypeError struct {
+		ResultErrorFields
+	}
+
+	// NumberAnyOfError. ErrorDetails: -
+	NumberAnyOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberOneOfError. ErrorDetails: -
+	NumberOneOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberAllOfError. ErrorDetails: -
+	NumberAllOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberNotError. ErrorDetails: -
+	NumberNotError struct {
+		ResultErrorFields
+	}
+
+	// MissingDependencyError. ErrorDetails: dependency
+	MissingDependencyError struct {
+		ResultErrorFields
+	}
+
+	// InternalError. ErrorDetails: error
+	InternalError struct {
+		ResultErrorFields
+	}
+
+	// EnumError. ErrorDetails: allowed
+	EnumError struct {
+		ResultErrorFields
+	}
+
+	// ArrayNoAdditionalItemsError. ErrorDetails: -
+	ArrayNoAdditionalItemsError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMinItemsError. ErrorDetails: min
+	ArrayMinItemsError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMaxItemsError. ErrorDetails: max
+	ArrayMaxItemsError struct {
+		ResultErrorFields
+	}
+
+	// ItemsMustBeUniqueError. ErrorDetails: type
+	ItemsMustBeUniqueError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMinPropertiesError. ErrorDetails: min
+	ArrayMinPropertiesError struct {
+		ResultErrorFields
+	}
+
+	// ArrayMaxPropertiesError. ErrorDetails: max
+	ArrayMaxPropertiesError struct {
+		ResultErrorFields
+	}
+
+	// AdditionalPropertyNotAllowedError. ErrorDetails: property
+	AdditionalPropertyNotAllowedError struct {
+		ResultErrorFields
+	}
+
+	// InvalidPropertyPatternError. ErrorDetails: property, pattern
+	InvalidPropertyPatternError struct {
+		ResultErrorFields
+	}
+
+	// StringLengthGTEError. ErrorDetails: min
+	StringLengthGTEError struct {
+		ResultErrorFields
+	}
+
+	// StringLengthLTEError. ErrorDetails: max
+	StringLengthLTEError struct {
+		ResultErrorFields
+	}
+
+	// DoesNotMatchPatternError. ErrorDetails: pattern
+	DoesNotMatchPatternError struct {
+		ResultErrorFields
+	}
+
+	// MultipleOfError. ErrorDetails: multiple
+	MultipleOfError struct {
+		ResultErrorFields
+	}
+
+	// NumberGTEError. ErrorDetails: min
+	NumberGTEError struct {
+		ResultErrorFields
+	}
+
+	// NumberGTError. ErrorDetails: min
+	NumberGTError struct {
+		ResultErrorFields
+	}
+
+	// NumberLTEError. ErrorDetails: max
+	NumberLTEError struct {
+		ResultErrorFields
+	}
+
+	// NumberLTError. ErrorDetails: max
+	NumberLTError struct {
+		ResultErrorFields
+	}
+)
+
+// newError takes a ResultError type and sets the type, context, description, details, value, and field
+func newError(err ResultError, context *jsonContext, value interface{}, locale locale, details ErrorDetails) {
+	var t string
+	var d string
+	switch err.(type) {
+	case *RequiredError:
+		t = "required"
+		d = locale.Required()
+	case *InvalidTypeError:
+		t = "invalid_type"
+		d = locale.InvalidType()
+	case *NumberAnyOfError:
+		t = "number_any_of"
+		d = locale.NumberAnyOf()
+	case *NumberOneOfError:
+		t = "number_one_of"
+		d = locale.NumberOneOf()
+	case *NumberAllOfError:
+		t = "number_all_of"
+		d = locale.NumberAllOf()
+	case *NumberNotError:
+		t = "number_not"
+		d = locale.NumberNot()
+	case *MissingDependencyError:
+		t = "missing_dependency"
+		d = locale.MissingDependency()
+	case *InternalError:
+		t = "internal"
+		d = locale.Internal()
+	case *EnumError:
+		t = "enum"
+		d = locale.Enum()
+	case *ArrayNoAdditionalItemsError:
+		t = "array_no_additional_items"
+		d = locale.ArrayNoAdditionalItems()
+	case *ArrayMinItemsError:
+		t = "array_min_items"
+		d = locale.ArrayMinItems()
+	case *ArrayMaxItemsError:
+		t = "array_max_items"
+		d = locale.ArrayMaxItems()
+	case *ItemsMustBeUniqueError:
+		t = "unique"
+		d = locale.Unique()
+	case *ArrayMinPropertiesError:
+		t = "array_min_properties"
+		d = locale.ArrayMinProperties()
+	case *ArrayMaxPropertiesError:
+		t = "array_max_properties"
+		d = locale.ArrayMaxProperties()
+	case *AdditionalPropertyNotAllowedError:
+		t = "additional_property_not_allowed"
+		d = locale.AdditionalPropertyNotAllowed()
+	case *InvalidPropertyPatternError:
+		t = "invalid_property_pattern"
+		d = locale.InvalidPropertyPattern()
+	case *StringLengthGTEError:
+		t = "string_gte"
+		d = locale.StringGTE()
+	case *StringLengthLTEError:
+		t = "string_lte"
+		d = locale.StringLTE()
+	case *DoesNotMatchPatternError:
+		t = "pattern"
+		d = locale.DoesNotMatchPattern()
+	case *MultipleOfError:
+		t = "multiple_of"
+		d = locale.MultipleOf()
+	case *NumberGTEError:
+		t = "number_gte"
+		d = locale.NumberGTE()
+	case *NumberGTError:
+		t = "number_gt"
+		d = locale.NumberGT()
+	case *NumberLTEError:
+		t = "number_lte"
+		d = locale.NumberLTE()
+	case *NumberLTError:
+		t = "number_lt"
+		d = locale.NumberLT()
+	}
+
+	err.SetType(t)
+	err.SetContext(context)
+	err.SetValue(value)
+	err.SetDetails(details)
+	details["field"] = err.Field()
+	err.SetDescription(formatErrorDescription(d, details))
+}
+
+// formatErrorDescription takes a string in this format: %field% is required
+// and converts it to a string with replacements. The fields come from
+// the ErrorDetails struct and vary for each type of error.
+func formatErrorDescription(s string, details ErrorDetails) string {
+	for name, val := range details {
+		s = strings.Replace(s, "%"+strings.ToLower(name)+"%", fmt.Sprintf("%s", val), -1)
+	}
+
+	return s
+}

--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -29,11 +29,11 @@ package gojsonschema
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"github.com/xeipuuv/gojsonreference"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/xeipuuv/gojsonreference"
 )
 
 // JSON loader interface
@@ -130,7 +130,7 @@ func (l *jsonReferenceLoader) loadFromHTTP(address string) (interface{}, error) 
 
 	// must return HTTP Status 200 OK
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(fmt.Sprintf(ERROR_MESSAGE_GET_HTTP_BAD_STATUS, resp.Status))
+		return nil, errors.New(formatErrorDescription(Locale.httpBadStatus(), ErrorDetails{"status": resp.Status}))
 	}
 
 	bodyBuff, err := ioutil.ReadAll(resp.Body)

--- a/locales.go
+++ b/locales.go
@@ -25,6 +25,231 @@
 
 package gojsonschema
 
+type (
+	// locale is an interface for definining custom error strings
+	locale interface {
+		Required() string
+		InvalidType() string
+		NumberAnyOf() string
+		NumberOneOf() string
+		NumberAllOf() string
+		NumberNot() string
+		MissingDependency() string
+		Internal() string
+		Enum() string
+		ArrayNoAdditionalItems() string
+		ArrayMinItems() string
+		ArrayMaxItems() string
+		Unique() string
+		ArrayMinProperties() string
+		ArrayMaxProperties() string
+		AdditionalPropertyNotAllowed() string
+		InvalidPropertyPattern() string
+		StringGTE() string
+		StringLTE() string
+		DoesNotMatchPattern() string
+		MultipleOf() string
+		NumberGTE() string
+		NumberGT() string
+		NumberLTE() string
+		NumberLT() string
+
+		// Schema validations
+		RegexPattern() string
+		GreaterThanZero() string
+		MustBeOfA() string
+		MustBeOfAn() string
+		CannotBeUsedWithout() string
+		CannotBeGT() string
+		MustBeOfType() string
+		MustBeValidRegex() string
+		MustBeGTEZero() string
+		KeyCannotBeGreaterThan() string
+		KeyItemsMustBeOfType() string
+		KeyItemsMustBeUnique() string
+		ReferenceMustBeCanonical() string
+		NotAValidType() string
+		Duplicated() string
+		httpBadStatus() string
+
+		// ErrorFormat
+		ErrorFormat() string
+	}
+
+	// DefaultLocale is the default locale for this package
+	DefaultLocale struct{}
+)
+
+func (l DefaultLocale) Required() string {
+	return `%property% is required`
+}
+
+func (l DefaultLocale) InvalidType() string {
+	return `Invalid type. Expected: %expected%, given: %given%`
+}
+
+func (l DefaultLocale) NumberAnyOf() string {
+	return `Must validate at least one schema (anyOf)`
+}
+
+func (l DefaultLocale) NumberOneOf() string {
+	return `Must validate one and only one schema (oneOf)`
+}
+
+func (l DefaultLocale) NumberAllOf() string {
+	return `Must validate all the schemas (allOf)`
+}
+
+func (l DefaultLocale) NumberNot() string {
+	return `Must not validate the schema (not)`
+}
+
+func (l DefaultLocale) MissingDependency() string {
+	return `Has a dependency on %dependency%`
+}
+
+func (l DefaultLocale) Internal() string {
+	return `Internal Error %error%`
+}
+
+func (l DefaultLocale) Enum() string {
+	return `%field% must be one of the following: %allowed%`
+}
+
+func (l DefaultLocale) ArrayNoAdditionalItems() string {
+	return `No additional items allowed on array`
+}
+
+func (l DefaultLocale) ArrayMinItems() string {
+	return `Array must have at least %min% items`
+}
+
+func (l DefaultLocale) ArrayMaxItems() string {
+	return `Array must have at most %max% items`
+}
+
+func (l DefaultLocale) Unique() string {
+	return `%type% items must be unique`
+}
+
+func (l DefaultLocale) ArrayMinProperties() string {
+	return `Must have at least %min% properties`
+}
+
+func (l DefaultLocale) ArrayMaxProperties() string {
+	return `Must have at most %max% properties`
+}
+
+func (l DefaultLocale) AdditionalPropertyNotAllowed() string {
+	return `Additional property %property% is not allowed`
+}
+
+func (l DefaultLocale) InvalidPropertyPattern() string {
+	return `Property "%property%" does not match pattern %pattern%`
+}
+
+func (l DefaultLocale) StringGTE() string {
+	return `String length must be greater than or equal to %min%`
+}
+
+func (l DefaultLocale) StringLTE() string {
+	return `String length must be less than or equal to %max%`
+}
+
+func (l DefaultLocale) DoesNotMatchPattern() string {
+	return `Does not match pattern '%pattern%'`
+}
+
+func (l DefaultLocale) MultipleOf() string {
+	return `Must be a multiple of %multiple%`
+}
+
+func (l DefaultLocale) NumberGTE() string {
+	return `Must be greater than or equal to %min%`
+}
+
+func (l DefaultLocale) NumberGT() string {
+	return `Must be greater than %min%`
+}
+
+func (l DefaultLocale) NumberLTE() string {
+	return `Must be less than or equal to %max%`
+}
+
+func (l DefaultLocale) NumberLT() string {
+	return `Must be less than %max%`
+}
+
+// Schema validators
+func (l DefaultLocale) RegexPattern() string {
+	return `Invalid regex pattern '%pattern%'`
+}
+
+func (l DefaultLocale) GreaterThanZero() string {
+	return `%number% must be strictly greater than 0`
+}
+
+func (l DefaultLocale) MustBeOfA() string {
+	return `%x% must be of a %y%`
+}
+
+func (l DefaultLocale) MustBeOfAn() string {
+	return `%x% must be of an %y%`
+}
+
+func (l DefaultLocale) CannotBeUsedWithout() string {
+	return `%x% cannot be used without %y%`
+}
+
+func (l DefaultLocale) CannotBeGT() string {
+	return `%x% cannot be greater than %y%`
+}
+
+func (l DefaultLocale) MustBeOfType() string {
+	return `%key% must be of type %type%`
+}
+
+func (l DefaultLocale) MustBeValidRegex() string {
+	return `%key% must be a valid regex`
+}
+
+func (l DefaultLocale) MustBeGTEZero() string {
+	return `%key% must be greater than or equal to 0`
+}
+
+func (l DefaultLocale) KeyCannotBeGreaterThan() string {
+	return `%key% cannot be greater than %y%`
+}
+
+func (l DefaultLocale) KeyItemsMustBeOfType() string {
+	return `%key% items must be %type%`
+}
+
+func (l DefaultLocale) KeyItemsMustBeUnique() string {
+	return `%key% items must be unique`
+}
+
+func (l DefaultLocale) ReferenceMustBeCanonical() string {
+	return `Reference %reference% must be canonical`
+}
+
+func (l DefaultLocale) NotAValidType() string {
+	return `%type% is not a valid type -- `
+}
+
+func (l DefaultLocale) Duplicated() string {
+	return `%type% type is duplicated`
+}
+
+func (l DefaultLocale) httpBadStatus() string {
+	return `Could not read schema from HTTP, response status is %status%`
+}
+
+// Replacement options: field, description, context, value
+func (l DefaultLocale) ErrorFormat() string {
+	return `%field%: %description%`
+}
+
 const (
 	STRING_NUMBER                     = "number"
 	STRING_ARRAY_OF_STRINGS           = "array of strings"
@@ -34,73 +259,7 @@ const (
 	STRING_PROPERTIES                 = "properties"
 	STRING_DEPENDENCY                 = "dependency"
 	STRING_PROPERTY                   = "property"
-
-	STRING_CONTEXT_ROOT         = "(root)"
-	STRING_ROOT_SCHEMA_PROPERTY = "(root)"
-
-	STRING_UNDEFINED = "undefined"
-
-	ERROR_MESSAGE_X_IS_NOT_A_VALID_TYPE = `%s is not a valid type`
-	ERROR_MESSAGE_X_TYPE_IS_DUPLICATED  = `%s type is duplicated`
-
-	ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y = `%s must be of type %s`
-
-	ERROR_MESSAGE_X_MUST_BE_A_Y  = `%s must be of a %s`
-	ERROR_MESSAGE_X_MUST_BE_AN_Y = `%s must be of an %s`
-
-	ERROR_MESSAGE_X_IS_MISSING_AND_REQUIRED  = `%s is missing and required`
-	ERROR_MESSAGE_MUST_BE_OF_TYPE_X          = `must be of type %s`
-	ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE     = `%s items must be unique`
-	ERROR_MESSAGE_X_ITEMS_MUST_BE_TYPE_Y     = `%s items must be %s`
-	ERROR_MESSAGE_DOES_NOT_MATCH_PATTERN     = `does not match pattern '%s'`
-	ERROR_MESSAGE_MUST_MATCH_ONE_ENUM_VALUES = `must match one of the enum values [%s]`
-
-	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL = `string length must be greater or equal to %d`
-	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL   = `string length must be lower or equal to %d`
-
-	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER_OR_EQUAL   = `must be lower than or equal to %s`
-	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER            = `must be lower than %s`
-	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER_OR_EQUAL = `must be greater than or equal to %s`
-	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER          = `must be greater than %s`
-
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ALLOF = `must validate all the schemas (allOf)`
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ONEOF = `must validate one and only one schema (oneOf)`
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ANYOF = `must validate at least one schema (anyOf)`
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_NOT   = `must not validate the schema (not)`
-
-	ERROR_MESSAGE_ARRAY_MIN_ITEMS = `array must have at least %d items`
-	ERROR_MESSAGE_ARRAY_MAX_ITEMS = `array must have at the most %d items`
-
-	ERROR_MESSAGE_ARRAY_MIN_PROPERTIES = `must have at least %d properties`
-	ERROR_MESSAGE_ARRAY_MAX_PROPERTIES = `must have at the most %d properties`
-
-	ERROR_MESSAGE_HAS_DEPENDENCY_ON = `has a dependency on %s`
-
-	ERROR_MESSAGE_MULTIPLE_OF = `must be a multiple of %s`
-
-	ERROR_MESSAGE_ARRAY_NO_ADDITIONAL_ITEM = `no additional item allowed on array`
-
-	ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED = `additional property "%s" is not allowed`
-	ERROR_MESSAGE_INVALID_PATTERN_PROPERTY        = `property "%s" does not match pattern %s`
-
-	ERROR_MESSAGE_INTERNAL = `internal error %s`
-
-	ERROR_MESSAGE_GET_HTTP_BAD_STATUS = `Could not read schema from HTTP, response status is %d`
-
-	ERROR_MESSAGE_NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT = `Invalid argument, must be a JSON string, a JSON reference string or a map[string]interface{}`
-
-	ERROR_MESSAGE_INVALID_REGEX_PATTERN = `Invalid regex pattern '%s'`
-	ERROR_MESSAGE_X_MUST_BE_VALID_REGEX = `%s must be a valid regex`
-
-	ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0 = `%s must be greater than or equal to 0`
-
-	ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y = `%s cannot be greater than %s`
-
-	ERROR_MESSAGE_X_MUST_BE_STRICTLY_GREATER_THAN_0 = `%s must be strictly greater than 0`
-
-	ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y = `%s cannot be used without %s`
-
-	ERROR_MESSAGE_REFERENCE_X_MUST_BE_CANONICAL = `Reference %s must be canonical`
-
-	RESULT_ERROR_FORMAT = `%s : %s, given %s` // context, description, value
+	STRING_UNDEFINED                  = "undefined"
+	STRING_CONTEXT_ROOT               = "(root)"
+	STRING_ROOT_SCHEMA_PROPERTY       = "(root)"
 )

--- a/result.go
+++ b/result.go
@@ -27,24 +27,109 @@ package gojsonschema
 
 import (
 	"fmt"
+	"strings"
 )
 
-type ResultError struct {
-	Context     *jsonContext // Tree like notation of the part that failed the validation. ex (root).a.b ...
-	Description string       // A human readable error message
-	Value       interface{}  // Value given by the JSON file that is the source of the error
+type (
+	// ErrorDetails is a map of details specific to each error.
+	// While the values will vary, every error will contain a "field" value
+	ErrorDetails map[string]interface{}
+
+	// ResultError is the interface that library errors must implement
+	ResultError interface {
+		Field() string
+		SetType(string)
+		Type() string
+		SetContext(*jsonContext)
+		Context() *jsonContext
+		SetDescription(string)
+		Description() string
+		SetValue(interface{})
+		Value() interface{}
+		SetDetails(ErrorDetails)
+		Details() ErrorDetails
+	}
+
+	// ResultErrorFields holds the fields for each ResultError implementation.
+	// ResultErrorFields implements the ResultError interface, so custom errors
+	// can be defined by just embedding this type
+	ResultErrorFields struct {
+		errorType   string       // A string with the type of error (i.e. invalid_type)
+		context     *jsonContext // Tree like notation of the part that failed the validation. ex (root).a.b ...
+		description string       // A human readable error message
+		value       interface{}  // Value given by the JSON file that is the source of the error
+		details     ErrorDetails
+	}
+
+	Result struct {
+		errors []ResultError
+		// Scores how well the validation matched. Useful in generating
+		// better error messages for anyOf and oneOf.
+		score int
+	}
+)
+
+// Field outputs the field name without the root context
+// i.e. firstName or person.firstName instead of (root).firstName or (root).person.firstName
+func (v *ResultErrorFields) Field() string {
+	if p, ok := v.Details()["property"]; ok {
+		if str, isString := p.(string); isString {
+			return str
+		}
+	}
+
+	return strings.TrimLeft(v.context.String(), STRING_ROOT_SCHEMA_PROPERTY+".")
 }
 
-func (v ResultError) String() string {
+func (v *ResultErrorFields) SetType(errorType string) {
+	v.errorType = errorType
+}
 
+func (v *ResultErrorFields) Type() string {
+	return v.errorType
+}
+
+func (v *ResultErrorFields) SetContext(context *jsonContext) {
+	v.context = context
+}
+
+func (v *ResultErrorFields) Context() *jsonContext {
+	return v.context
+}
+
+func (v *ResultErrorFields) SetDescription(description string) {
+	v.description = description
+}
+
+func (v *ResultErrorFields) Description() string {
+	return v.description
+}
+
+func (v *ResultErrorFields) SetValue(value interface{}) {
+	v.value = value
+}
+
+func (v *ResultErrorFields) Value() interface{} {
+	return v.value
+}
+
+func (v *ResultErrorFields) SetDetails(details ErrorDetails) {
+	v.details = details
+}
+
+func (v *ResultErrorFields) Details() ErrorDetails {
+	return v.details
+}
+
+func (v ResultErrorFields) String() string {
 	// as a fallback, the value is displayed go style
-	valueString := fmt.Sprintf("%v", v.Value)
+	valueString := fmt.Sprintf("%v", v.value)
 
 	// marshal the go value value to json
 	if v.Value == nil {
 		valueString = TYPE_NULL
 	} else {
-		if vs, err := marshalToJsonString(v.Value); err == nil {
+		if vs, err := marshalToJsonString(v.value); err == nil {
 			if vs == nil {
 				valueString = TYPE_NULL
 			} else {
@@ -53,14 +138,12 @@ func (v ResultError) String() string {
 		}
 	}
 
-	return fmt.Sprintf(RESULT_ERROR_FORMAT, v.Context, v.Description, valueString)
-}
-
-type Result struct {
-	errors []ResultError
-	// Scores how well the validation matched. Useful in generating
-	// better error messages for anyOf and oneOf.
-	score int
+	return formatErrorDescription(Locale.ErrorFormat(), ErrorDetails{
+		"context":     v.context.String(),
+		"description": v.description,
+		"value":       valueString,
+		"field":       v.Field(),
+	})
 }
 
 func (v *Result) Valid() bool {
@@ -71,8 +154,9 @@ func (v *Result) Errors() []ResultError {
 	return v.errors
 }
 
-func (v *Result) addError(context *jsonContext, value interface{}, description string) {
-	v.errors = append(v.errors, ResultError{Context: context, Value: value, Description: description})
+func (v *Result) addError(err ResultError, context *jsonContext, value interface{}, details ErrorDetails) {
+	newError(err, context, value, Locale, details)
+	v.errors = append(v.errors, err)
 	v.score -= 2 // results in a net -1 when added to the +1 we get at the end of the validation function
 }
 

--- a/schemaPool.go
+++ b/schemaPool.go
@@ -28,7 +28,7 @@ package gojsonschema
 
 import (
 	"errors"
-	"fmt"
+
 	"github.com/xeipuuv/gojsonreference"
 )
 
@@ -66,7 +66,10 @@ func (p *schemaPool) GetDocument(reference gojsonreference.JsonReference) (*sche
 
 	// It is not possible to load anything that is not canonical...
 	if !reference.IsCanonical() {
-		return nil, errors.New(fmt.Sprintf(ERROR_MESSAGE_REFERENCE_X_MUST_BE_CANONICAL, reference))
+		return nil, errors.New(formatErrorDescription(
+			Locale.ReferenceMustBeCanonical(),
+			ErrorDetails{"reference": reference},
+		))
 	}
 
 	refToUrl := reference

--- a/schemaType.go
+++ b/schemaType.go
@@ -44,11 +44,11 @@ func (t *jsonSchemaType) IsTyped() bool {
 func (t *jsonSchemaType) Add(etype string) error {
 
 	if !isStringInSlice(JSON_TYPES, etype) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_IS_NOT_A_VALID_TYPE, etype))
+		return errors.New(formatErrorDescription(Locale.NotAValidType(), ErrorDetails{"type": etype}))
 	}
 
 	if t.Contains(etype) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_TYPE_IS_DUPLICATED, etype))
+		return errors.New(formatErrorDescription(Locale.Duplicated(), ErrorDetails{"type": etype}))
 	}
 
 	t.types = append(t.types, etype)

--- a/subSchema.go
+++ b/subSchema.go
@@ -28,10 +28,10 @@ package gojsonschema
 
 import (
 	"errors"
-	"fmt"
-	"github.com/xeipuuv/gojsonreference"
 	"regexp"
 	"strings"
+
+	"github.com/xeipuuv/gojsonreference"
 )
 
 const (
@@ -142,7 +142,10 @@ func (s *subSchema) AddEnum(i interface{}) error {
 	}
 
 	if isStringInSlice(s.enum, *is) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE, KEY_ENUM))
+		return errors.New(formatErrorDescription(
+			Locale.KeyItemsMustBeUnique(),
+			ErrorDetails{"key": KEY_ENUM},
+		))
 	}
 
 	s.enum = append(s.enum, *is)
@@ -179,7 +182,10 @@ func (s *subSchema) SetNot(subSchema *subSchema) {
 func (s *subSchema) AddRequired(value string) error {
 
 	if isStringInSlice(s.required, value) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE, KEY_REQUIRED))
+		return errors.New(formatErrorDescription(
+			Locale.KeyItemsMustBeUnique(),
+			ErrorDetails{"key": KEY_REQUIRED},
+		))
 	}
 
 	s.required = append(s.required, value)

--- a/validation.go
+++ b/validation.go
@@ -26,7 +26,6 @@
 package gojsonschema
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -90,9 +89,16 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 
 	// Check for null value
 	if currentNode == nil {
-
 		if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_NULL) {
-			result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+			result.addError(
+				new(InvalidTypeError),
+				context,
+				currentNode,
+				ErrorDetails{
+					"expected": currentSubSchema.types.String(),
+					"given":    TYPE_NULL,
+				},
+			)
 			return
 		}
 
@@ -111,7 +117,15 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 		case reflect.Slice:
 
 			if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_ARRAY) {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				result.addError(
+					new(InvalidTypeError),
+					context,
+					currentNode,
+					ErrorDetails{
+						"expected": currentSubSchema.types.String(),
+						"given":    TYPE_ARRAY,
+					},
+				)
 				return
 			}
 
@@ -126,7 +140,15 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 
 		case reflect.Map:
 			if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_OBJECT) {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				result.addError(
+					new(InvalidTypeError),
+					context,
+					currentNode,
+					ErrorDetails{
+						"expected": currentSubSchema.types.String(),
+						"given":    TYPE_OBJECT,
+					},
+				)
 				return
 			}
 
@@ -153,7 +175,15 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 		case reflect.Bool:
 
 			if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_BOOLEAN) {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				result.addError(
+					new(InvalidTypeError),
+					context,
+					currentNode,
+					ErrorDetails{
+						"expected": currentSubSchema.types.String(),
+						"given":    TYPE_BOOLEAN,
+					},
+				)
 				return
 			}
 
@@ -167,7 +197,15 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 		case reflect.String:
 
 			if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_STRING) {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				result.addError(
+					new(InvalidTypeError),
+					context,
+					currentNode,
+					ErrorDetails{
+						"expected": currentSubSchema.types.String(),
+						"given":    TYPE_STRING,
+					},
+				)
 				return
 			}
 
@@ -189,7 +227,15 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 			validType := currentSubSchema.types.Contains(TYPE_NUMBER) || (isInteger && currentSubSchema.types.Contains(TYPE_INTEGER))
 
 			if currentSubSchema.types.IsTyped() && !validType {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				result.addError(
+					new(InvalidTypeError),
+					context,
+					currentNode,
+					ErrorDetails{
+						"expected": currentSubSchema.types.String(),
+						"given":    TYPE_INTEGER,
+					},
+				)
 				return
 			}
 
@@ -226,7 +272,7 @@ func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode inte
 		}
 		if !validatedAnyOf {
 
-			result.addError(context, currentNode, ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ANYOF)
+			result.addError(new(NumberAnyOfError), context, currentNode, ErrorDetails{})
 
 			if bestValidationResult != nil {
 				// add error messages of closest matching subSchema as
@@ -252,7 +298,7 @@ func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode inte
 
 		if nbValidated != 1 {
 
-			result.addError(context, currentNode, ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ONEOF)
+			result.addError(new(NumberOneOfError), context, currentNode, ErrorDetails{})
 
 			if nbValidated == 0 {
 				// add error messages of closest matching subSchema as
@@ -275,14 +321,14 @@ func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode inte
 		}
 
 		if nbValidated != len(currentSubSchema.allOf) {
-			result.addError(context, currentNode, ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ALLOF)
+			result.addError(new(NumberAllOfError), context, currentNode, ErrorDetails{})
 		}
 	}
 
 	if currentSubSchema.not != nil {
 		validationResult := currentSubSchema.not.subValidateWithContext(currentNode, context)
 		if validationResult.Valid() {
-			result.addError(context, currentNode, ERROR_MESSAGE_NUMBER_MUST_VALIDATE_NOT)
+			result.addError(new(NumberNotError), context, currentNode, ErrorDetails{})
 		}
 	}
 
@@ -295,7 +341,12 @@ func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode inte
 					case []string:
 						for _, dependOnKey := range dependency {
 							if _, dependencyResolved := currentNode.(map[string]interface{})[dependOnKey]; !dependencyResolved {
-								result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_HAS_DEPENDENCY_ON, dependOnKey))
+								result.addError(
+									new(MissingDependencyError),
+									context,
+									currentNode,
+									ErrorDetails{"dependency": dependOnKey},
+								)
 							}
 						}
 
@@ -320,10 +371,17 @@ func (v *subSchema) validateCommon(currentSubSchema *subSchema, value interface{
 	if len(currentSubSchema.enum) > 0 {
 		has, err := currentSubSchema.ContainsEnum(value)
 		if err != nil {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_INTERNAL, err))
+			result.addError(new(InternalError), context, value, ErrorDetails{"error": err})
 		}
 		if !has {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_MUST_MATCH_ONE_ENUM_VALUES, strings.Join(currentSubSchema.enum, ",")))
+			result.addError(
+				new(EnumError),
+				context,
+				value,
+				ErrorDetails{
+					"allowed": strings.Join(currentSubSchema.enum, ", "),
+				},
+			)
 		}
 	}
 
@@ -360,7 +418,7 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 				switch currentSubSchema.additionalItems.(type) {
 				case bool:
 					if !currentSubSchema.additionalItems.(bool) {
-						result.addError(context, value, ERROR_MESSAGE_ARRAY_NO_ADDITIONAL_ITEM)
+						result.addError(new(ArrayNoAdditionalItemsError), context, value, ErrorDetails{})
 					}
 				case *subSchema:
 					additionalItemSchema := currentSubSchema.additionalItems.(*subSchema)
@@ -377,12 +435,22 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 	// minItems & maxItems
 	if currentSubSchema.minItems != nil {
 		if nbItems < *currentSubSchema.minItems {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ARRAY_MIN_ITEMS, *currentSubSchema.minItems))
+			result.addError(
+				new(ArrayMinItemsError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minItems},
+			)
 		}
 	}
 	if currentSubSchema.maxItems != nil {
 		if nbItems > *currentSubSchema.maxItems {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ARRAY_MAX_ITEMS, *currentSubSchema.maxItems))
+			result.addError(
+				new(ArrayMaxItemsError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxItems},
+			)
 		}
 	}
 
@@ -392,10 +460,15 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 		for _, v := range value {
 			vString, err := marshalToJsonString(v)
 			if err != nil {
-				result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_INTERNAL, err))
+				result.addError(new(InternalError), context, value, ErrorDetails{"err": err})
 			}
 			if isStringInSlice(stringifiedItems, *vString) {
-				result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE, TYPE_ARRAY))
+				result.addError(
+					new(ItemsMustBeUniqueError),
+					context,
+					value,
+					ErrorDetails{"type": TYPE_ARRAY},
+				)
 			}
 			stringifiedItems = append(stringifiedItems, *vString)
 		}
@@ -412,12 +485,22 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 	// minProperties & maxProperties:
 	if currentSubSchema.minProperties != nil {
 		if len(value) < *currentSubSchema.minProperties {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ARRAY_MIN_PROPERTIES, *currentSubSchema.minProperties))
+			result.addError(
+				new(ArrayMinPropertiesError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minProperties},
+			)
 		}
 	}
 	if currentSubSchema.maxProperties != nil {
 		if len(value) > *currentSubSchema.maxProperties {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ARRAY_MAX_PROPERTIES, *currentSubSchema.maxProperties))
+			result.addError(
+				new(ArrayMaxPropertiesError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxProperties},
+			)
 		}
 	}
 
@@ -427,7 +510,12 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 		if ok {
 			result.incrementScore()
 		} else {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_X_IS_MISSING_AND_REQUIRED, fmt.Sprintf(`"%s" %s`, requiredProperty, STRING_PROPERTY)))
+			result.addError(
+				new(RequiredError),
+				context,
+				value,
+				ErrorDetails{"property": requiredProperty},
+			)
 		}
 	}
 
@@ -453,13 +541,23 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 					if found {
 
 						if pp_has && !pp_match {
-							result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED, pk))
+							result.addError(
+								new(AdditionalPropertyNotAllowedError),
+								context,
+								value,
+								ErrorDetails{"property": pk},
+							)
 						}
 
 					} else {
 
 						if !pp_has || !pp_match {
-							result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED, pk))
+							result.addError(
+								new(AdditionalPropertyNotAllowedError),
+								context,
+								value,
+								ErrorDetails{"property": pk},
+							)
 						}
 
 					}
@@ -506,7 +604,15 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 
 			if pp_has && !pp_match {
 
-				result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_INVALID_PATTERN_PROPERTY, pk, currentSubSchema.PatternPropertiesString()))
+				result.addError(
+					new(InvalidPropertyPatternError),
+					context,
+					value,
+					ErrorDetails{
+						"property": pk,
+						"pattern":  currentSubSchema.PatternPropertiesString(),
+					},
+				)
 			}
 
 		}
@@ -560,19 +666,34 @@ func (v *subSchema) validateString(currentSubSchema *subSchema, value interface{
 	// minLength & maxLength:
 	if currentSubSchema.minLength != nil {
 		if utf8.RuneCount([]byte(stringValue)) < *currentSubSchema.minLength {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL, *currentSubSchema.minLength))
+			result.addError(
+				new(StringLengthGTEError),
+				context,
+				value,
+				ErrorDetails{"min": *currentSubSchema.minLength},
+			)
 		}
 	}
 	if currentSubSchema.maxLength != nil {
 		if utf8.RuneCount([]byte(stringValue)) > *currentSubSchema.maxLength {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL, *currentSubSchema.maxLength))
+			result.addError(
+				new(StringLengthLTEError),
+				context,
+				value,
+				ErrorDetails{"max": *currentSubSchema.maxLength},
+			)
 		}
 	}
 
 	// pattern:
 	if currentSubSchema.pattern != nil {
 		if !currentSubSchema.pattern.MatchString(stringValue) {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_DOES_NOT_MATCH_PATTERN, currentSubSchema.pattern))
+			result.addError(
+				new(DoesNotMatchPatternError),
+				context,
+				value,
+				ErrorDetails{"pattern": currentSubSchema.pattern},
+			)
 
 		}
 	}
@@ -595,7 +716,12 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 	// multipleOf:
 	if currentSubSchema.multipleOf != nil {
 		if !isFloat64AnInteger(float64Value / *currentSubSchema.multipleOf) {
-			result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_MULTIPLE_OF, resultErrorFormatNumber(*currentSubSchema.multipleOf)))
+			result.addError(
+				new(MultipleOfError),
+				context,
+				resultErrorFormatNumber(float64Value),
+				ErrorDetails{"multiple": *currentSubSchema.multipleOf},
+			)
 		}
 	}
 
@@ -603,11 +729,25 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 	if currentSubSchema.maximum != nil {
 		if currentSubSchema.exclusiveMaximum {
 			if float64Value >= *currentSubSchema.maximum {
-				result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_NUMBER_MUST_BE_LOWER_OR_EQUAL, resultErrorFormatNumber(*currentSubSchema.maximum)))
+				result.addError(
+					new(NumberGTEError),
+					context,
+					resultErrorFormatNumber(float64Value),
+					ErrorDetails{
+						"min": resultErrorFormatNumber(*currentSubSchema.maximum),
+					},
+				)
 			}
 		} else {
 			if float64Value > *currentSubSchema.maximum {
-				result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_NUMBER_MUST_BE_LOWER, resultErrorFormatNumber(*currentSubSchema.maximum)))
+				result.addError(
+					new(NumberGTError),
+					context,
+					resultErrorFormatNumber(float64Value),
+					ErrorDetails{
+						"min": resultErrorFormatNumber(*currentSubSchema.maximum),
+					},
+				)
 			}
 		}
 	}
@@ -616,11 +756,25 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 	if currentSubSchema.minimum != nil {
 		if currentSubSchema.exclusiveMinimum {
 			if float64Value <= *currentSubSchema.minimum {
-				result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_NUMBER_MUST_BE_GREATER_OR_EQUAL, resultErrorFormatNumber(*currentSubSchema.minimum)))
+				result.addError(
+					new(NumberLTEError),
+					context,
+					resultErrorFormatNumber(float64Value),
+					ErrorDetails{
+						"max": resultErrorFormatNumber(*currentSubSchema.minimum),
+					},
+				)
 			}
 		} else {
 			if float64Value < *currentSubSchema.minimum {
-				result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_NUMBER_MUST_BE_GREATER, resultErrorFormatNumber(*currentSubSchema.minimum)))
+				result.addError(
+					new(NumberLTError),
+					context,
+					resultErrorFormatNumber(float64Value),
+					ErrorDetails{
+						"max": resultErrorFormatNumber(*currentSubSchema.minimum),
+					},
+				)
 			}
 		}
 	}


### PR DESCRIPTION
This pull request adds additional context to error messages and allows users to override locales with their own error messages. The locales support more flexible messages with a new ErrorDetails type and basic string replacements over fmt.Sprintf.

The reason for this pull request is for more context so library users can both customize error messages with their own locales, as well as have more flexibility to programmatically determine what errors occurred and create their own custom error messages (if they need to).

Currently if validation determines a "firstName" field is missing, there is no way to know what happened and pass an error message on with more context than just a string. You can determine that the error was on the "firstName" field based on the jsonContext, but you can't tell what type of error is the culprit (i.e. was the field required and not given, was it of the wrong type, did it not meet enum criteria?). So transforming that error into say, a JSON response with error codes and custom messages, isn't currently possible.

This pull request does a few things:
 * Changes the locales from a group of constants that could previously not be changed to an interface with a default implementation that works automatically with no intervention from the user.
 * Adds enhanced ErrorDetails to each error and allows locales to tap into those using basic string replacements -- including the field name -- in every error message.
 * Adds a Type() method to each error to determine which error occurred (i.e. required and missing error returns the string "required" when calling Type() on the error. Enum errors returns "enum" when calling Type() on the error)
 * Makes each error it's own type implementing the ResultError interface. This allows for type checking on the errors (i.e. InvalidTypeError, RequiredError, ArrayMinItemsError, StringLengthGTEError, etc).
 * Allows users to overwrite the result of err.String() by creating their own custom format.

This change should be backwards compatible for users who are just printing errors as the err still has a String() method. However, some of the strings changed slightly and due to the ResultError interface previously public variables on the error are now private and accessible via getters and setters.

Let me know your thoughts. If you like the implementation, I'll put together some unit tests to cover the new functionality so it can be merged in. All current unit tests are passing.