### PR TITLE
ResultError now carries a Code property (string) that acts as a symbo…

### DIFF
--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -29,7 +29,6 @@ package gojsonschema
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"github.com/xeipuuv/gojsonreference"
 	"io/ioutil"
 	"net/http"
@@ -130,7 +129,8 @@ func (l *jsonReferenceLoader) loadFromHTTP(address string) (interface{}, error) 
 
 	// must return HTTP Status 200 OK
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(fmt.Sprintf(ERROR_MESSAGE_GET_HTTP_BAD_STATUS, resp.Status))
+		message := ERROR_MESSAGE_GET_HTTP_BAD_STATUS(resp.Status)
+		return nil, errors.New(message.Description)
 	}
 
 	bodyBuff, err := ioutil.ReadAll(resp.Body)

--- a/locales.go
+++ b/locales.go
@@ -19,11 +19,16 @@
 // repository-name  gojsonschema
 // repository-desc  An implementation of JSON Schema, based on IETF's draft v4 - Go language.
 //
-// description      Contains const string and messages.
+// description      Contains const string and MessageMakers.
 //
 // created          01-01-2015
 
 package gojsonschema
+
+import (
+	"errors"
+	"fmt"
+)
 
 const (
 	STRING_NUMBER                     = "number"
@@ -38,69 +43,94 @@ const (
 	STRING_CONTEXT_ROOT         = "(root)"
 	STRING_ROOT_SCHEMA_PROPERTY = "(root)"
 
-	STRING_UNDEFINED = "undefined"
-
-	ERROR_MESSAGE_X_IS_NOT_A_VALID_TYPE = `%s is not a valid type`
-	ERROR_MESSAGE_X_TYPE_IS_DUPLICATED  = `%s type is duplicated`
-
-	ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y = `%s must be of type %s`
-
-	ERROR_MESSAGE_X_MUST_BE_A_Y  = `%s must be of a %s`
-	ERROR_MESSAGE_X_MUST_BE_AN_Y = `%s must be of an %s`
-
-	ERROR_MESSAGE_X_IS_MISSING_AND_REQUIRED  = `%s is missing and required`
-	ERROR_MESSAGE_MUST_BE_OF_TYPE_X          = `must be of type %s`
-	ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE     = `%s items must be unique`
-	ERROR_MESSAGE_X_ITEMS_MUST_BE_TYPE_Y     = `%s items must be %s`
-	ERROR_MESSAGE_DOES_NOT_MATCH_PATTERN     = `does not match pattern '%s'`
-	ERROR_MESSAGE_MUST_MATCH_ONE_ENUM_VALUES = `must match one of the enum values [%s]`
-
-	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL = `string length must be greater or equal to %d`
-	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL   = `string length must be lower or equal to %d`
-
-	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER_OR_EQUAL   = `must be lower than or equal to %s`
-	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER            = `must be lower than %s`
-	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER_OR_EQUAL = `must be greater than or equal to %s`
-	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER          = `must be greater than %s`
-
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ALLOF = `must validate all the schemas (allOf)`
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ONEOF = `must validate one and only one schema (oneOf)`
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ANYOF = `must validate at least one schema (anyOf)`
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_NOT   = `must not validate the schema (not)`
-
-	ERROR_MESSAGE_ARRAY_MIN_ITEMS = `array must have at least %d items`
-	ERROR_MESSAGE_ARRAY_MAX_ITEMS = `array must have at the most %d items`
-
-	ERROR_MESSAGE_ARRAY_MIN_PROPERTIES = `must have at least %d properties`
-	ERROR_MESSAGE_ARRAY_MAX_PROPERTIES = `must have at the most %d properties`
-
-	ERROR_MESSAGE_HAS_DEPENDENCY_ON = `has a dependency on %s`
-
-	ERROR_MESSAGE_MULTIPLE_OF = `must be a multiple of %s`
-
-	ERROR_MESSAGE_ARRAY_NO_ADDITIONAL_ITEM = `no additional item allowed on array`
-
-	ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED = `additional property "%s" is not allowed`
-	ERROR_MESSAGE_INVALID_PATTERN_PROPERTY        = `property "%s" does not match pattern %s`
-
-	ERROR_MESSAGE_INTERNAL = `internal error %s`
-
-	ERROR_MESSAGE_GET_HTTP_BAD_STATUS = `Could not read schema from HTTP, response status is %d`
-
-	ERROR_MESSAGE_NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT = `Invalid argument, must be a JSON string, a JSON reference string or a map[string]interface{}`
-
-	ERROR_MESSAGE_INVALID_REGEX_PATTERN = `Invalid regex pattern '%s'`
-	ERROR_MESSAGE_X_MUST_BE_VALID_REGEX = `%s must be a valid regex`
-
-	ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0 = `%s must be greater than or equal to 0`
-
-	ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y = `%s cannot be greater than %s`
-
-	ERROR_MESSAGE_X_MUST_BE_STRICTLY_GREATER_THAN_0 = `%s must be strictly greater than 0`
-
-	ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y = `%s cannot be used without %s`
-
-	ERROR_MESSAGE_REFERENCE_X_MUST_BE_CANONICAL = `Reference %s must be canonical`
-
+	STRING_UNDEFINED    = "undefined"
 	RESULT_ERROR_FORMAT = `%s : %s, given %s` // context, description, value
+)
+
+type Message struct {
+	Code, // A code representing the error reason for use by the client
+	Description string // The json schema English MessageMaker describing the problem
+}
+
+// Error produces a typical error holding the formatted description
+func (m Message) Error() error {
+	return errors.New(m.Description)
+}
+
+// messageMaker is a closure holding error specific code and format to product a Message
+type messageMaker func(...interface{}) Message
+
+func newMessageMaker(code, format string) messageMaker {
+	return func(args ...interface{}) Message {
+		description := fmt.Sprintf(format, args...)
+		return Message{
+			Code:        code,
+			Description: description,
+		}
+	}
+}
+
+var (
+	ERROR_MESSAGE_X_IS_NOT_A_VALID_TYPE = newMessageMaker("X_IS_NOT_A_VALID_TYPE", `%s is not a valid type`)
+
+	ERROR_MESSAGE_X_TYPE_IS_DUPLICATED = newMessageMaker("X_TYPE_IS_DUPLICATED", `%s type is duplicated`)
+
+	ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y = newMessageMaker("X_MUST_BE_OF_TYPE_Y", `%s must be of type %s`)
+
+	ERROR_MESSAGE_X_MUST_BE_A_Y  = newMessageMaker("X_MUST_BE_A_Y", `%s must be of a %s`)
+	ERROR_MESSAGE_X_MUST_BE_AN_Y = newMessageMaker("X_MUST_BE_AN_Y", `%s must be of an %s`)
+
+	ERROR_MESSAGE_X_IS_MISSING_AND_REQUIRED  = newMessageMaker("X_IS_MISSING_AND_REQUIRED", `%s is missing and required`)
+	ERROR_MESSAGE_MUST_BE_OF_TYPE_X          = newMessageMaker("MUST_BE_OF_TYPE_X", `must be of type %s`)
+	ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE     = newMessageMaker("X_ITEMS_MUST_BE_UNIQUE", `%s items must be unique`)
+	ERROR_MESSAGE_X_ITEMS_MUST_BE_TYPE_Y     = newMessageMaker("X_ITEMS_MUST_BE_TYPE_Y", `%s items must be %s`)
+	ERROR_MESSAGE_DOES_NOT_MATCH_PATTERN     = newMessageMaker("DOES_NOT_MATCH_PATTERN", `does not match pattern '%s'`)
+	ERROR_MESSAGE_MUST_MATCH_ONE_ENUM_VALUES = newMessageMaker("MUST_MATCH_ONE_ENUM_VALUES", `must match one of the enum values [%s]`)
+
+	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL = newMessageMaker("STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL", `string length must be greater or equal to %d`)
+	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL   = newMessageMaker("STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL", `string length must be lower or equal to %d`)
+
+	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER_OR_EQUAL   = newMessageMaker("NUMBER_MUST_BE_LOWER_OR_EQUAL", `must be lower than or equal to %s`)
+	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER            = newMessageMaker("NUMBER_MUST_BE_LOWER", `must be lower than %s`)
+	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER_OR_EQUAL = newMessageMaker("NUMBER_MUST_BE_GREATER_OR_EQUAL", `must be greater than or equal to %s`)
+	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER          = newMessageMaker("NUMBER_MUST_BE_GREATER", `must be greater than %s`)
+
+	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ALLOF = newMessageMaker("NUMBER_MUST_VALIDATE_ALLOF", `must validate all the schemas (allOf)`)
+	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ONEOF = newMessageMaker("NUMBER_MUST_VALIDATE_ONEOF", `must validate one and only one schema (oneOf)`)
+	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ANYOF = newMessageMaker("NUMBER_MUST_VALIDATE_ANYOF", `must validate at least one schema (anyOf)`)
+	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_NOT   = newMessageMaker("NUMBER_MUST_VALIDATE_NOT", `must not validate the schema (not)`)
+
+	ERROR_MESSAGE_ARRAY_MIN_ITEMS = newMessageMaker("ARRAY_MIN_ITEMS", `array must have at least %d items`)
+	ERROR_MESSAGE_ARRAY_MAX_ITEMS = newMessageMaker("ARRAY_MAX_ITEMS", `array must have at the most %d items`)
+
+	ERROR_MESSAGE_ARRAY_MIN_PROPERTIES = newMessageMaker("ARRAY_MIN_PROPERTIES", `must have at least %d properties`)
+	ERROR_MESSAGE_ARRAY_MAX_PROPERTIES = newMessageMaker("ARRAY_MAX_PROPERTIES", `must have at the most %d properties`)
+
+	ERROR_MESSAGE_HAS_DEPENDENCY_ON = newMessageMaker("HAS_DEPENDENCY_ON", `has a dependency on %s`)
+
+	ERROR_MESSAGE_MULTIPLE_OF = newMessageMaker("MULTIPLE_OF", `must be a multiple of %s`)
+
+	ERROR_MESSAGE_ARRAY_NO_ADDITIONAL_ITEM = newMessageMaker("ARRAY_NO_ADDITIONAL_ITEM", `no additional item allowed on array`)
+
+	ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED = newMessageMaker("ADDITIONAL_PROPERTY_NOT_ALLOWED", `additional property "%s" is not allowed`)
+	ERROR_MESSAGE_INVALID_PATTERN_PROPERTY        = newMessageMaker("INVALID_PATTERN_PROPERTY", `property "%s" does not match pattern %s`)
+
+	ERROR_MESSAGE_INTERNAL = newMessageMaker("INTERNAL", `internal error %s`)
+
+	ERROR_MESSAGE_GET_HTTP_BAD_STATUS = newMessageMaker("GET_HTTP_BAD_STATUS", `Could not read schema from HTTP, response status is %d`)
+
+	ERROR_MESSAGE_NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT = newMessageMaker("NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT", `Invalid argument, must be a JSON string, a JSON reference string or a map[string]interface{}`)
+
+	ERROR_MESSAGE_INVALID_REGEX_PATTERN = newMessageMaker("INVALID_REGEX_PATTERN", `Invalid regex pattern '%s'`)
+	ERROR_MESSAGE_X_MUST_BE_VALID_REGEX = newMessageMaker("X_MUST_BE_VALID_REGEX", `%s must be a valid regex`)
+
+	ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0 = newMessageMaker("X_MUST_BE_GREATER_OR_TO_0", `%s must be greater than or equal to 0`)
+
+	ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y = newMessageMaker("X_CANNOT_BE_GREATER_THAN_Y", `%s cannot be greater than %s`)
+
+	ERROR_MESSAGE_X_MUST_BE_STRICTLY_GREATER_THAN_0 = newMessageMaker("X_MUST_BE_STRICTLY_GREATER_THAN_0", `%s must be strictly greater than 0`)
+
+	ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y = newMessageMaker("X_CANNOT_BE_USED_WITHOUT_Y", `%s cannot be used without %s`)
+
+	ERROR_MESSAGE_REFERENCE_X_MUST_BE_CANONICAL = newMessageMaker("REFERENCE_X_MUST_BE_CANONICAL", `Reference %s must be canonical`)
 )

--- a/locales.go
+++ b/locales.go
@@ -45,6 +45,47 @@ const (
 
 	STRING_UNDEFINED    = "undefined"
 	RESULT_ERROR_FORMAT = `%s : %s, given %s` // context, description, value
+
+	ARRAY_MIN_ITEMS                        = "ARRAY_MIN_ITEMS"
+	ARRAY_MAX_ITEMS                        = "ARRAY_MAX_ITEMS"
+	ARRAY_MIN_PROPERTIES                   = "ARRAY_MIN_PROPERTIES"
+	ARRAY_MAX_PROPERTIES                   = "ARRAY_MAX_PROPERTIES"
+	ARRAY_NO_ADDITIONAL_ITEM               = "ARRAY_NO_ADDITIONAL_ITEM"
+	ADDITIONAL_PROPERTY_NOT_ALLOWED        = "ADDITIONAL_PROPERTY_NOT_ALLOWED"
+	DOES_NOT_MATCH_PATTERN                 = "DOES_NOT_MATCH_PATTERN"
+	HAS_DEPENDENCY_ON                      = "HAS_DEPENDENCY_ON"
+	MULTIPLE_OF                            = "MULTIPLE_OF"
+	GET_HTTP_BAD_STATUS                    = "GET_HTTP_BAD_STATUS"
+	INVALID_PATTERN_PROPERTY               = "INVALID_PATTERN_PROPERTY"
+	INTERNAL                               = "INTERNAL"
+	INVALID_REGEX_PATTERN                  = "INVALID_REGEX_PATTERN"
+	MUST_MATCH_ONE_ENUM_VALUES             = "MUST_MATCH_ONE_ENUM_VALUES"
+	NUMBER_MUST_BE_LOWER_OR_EQUAL          = "NUMBER_MUST_BE_LOWER_OR_EQUAL"
+	NUMBER_MUST_BE_LOWER                   = "NUMBER_MUST_BE_LOWER"
+	NUMBER_MUST_BE_GREATER_OR_EQUAL        = "NUMBER_MUST_BE_GREATER_OR_EQUAL"
+	NUMBER_MUST_BE_GREATER                 = "NUMBER_MUST_BE_GREATER"
+	NUMBER_MUST_VALIDATE_ALLOF             = "NUMBER_MUST_VALIDATE_ALLOF"
+	NUMBER_MUST_VALIDATE_ONEOF             = "NUMBER_MUST_VALIDATE_ONEOF"
+	NUMBER_MUST_VALIDATE_ANYOF             = "NUMBER_MUST_VALIDATE_ANYOF"
+	NUMBER_MUST_VALIDATE_NOT               = "NUMBER_MUST_VALIDATE_NOT"
+	REFERENCE_X_MUST_BE_CANONICAL          = "REFERENCE_X_MUST_BE_CANONICAL"
+	STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL = "STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL"
+	STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL   = "STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL"
+	MUST_BE_OF_TYPE_X                      = "MUST_BE_OF_TYPE_X"
+	NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT   = "NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT"
+	X_IS_NOT_A_VALID_TYPE                  = "X_IS_NOT_A_VALID_TYPE"
+	X_TYPE_IS_DUPLICATED                   = "X_TYPE_IS_DUPLICATED"
+	X_MUST_BE_OF_TYPE_Y                    = "X_MUST_BE_OF_TYPE_Y"
+	X_MUST_BE_A_Y                          = "X_MUST_BE_A_Y"
+	X_MUST_BE_AN_Y                         = "X_MUST_BE_AN_Y"
+	X_IS_MISSING_AND_REQUIRED              = "X_IS_MISSING_AND_REQUIRED"
+	X_MUST_BE_VALID_REGEX                  = "X_MUST_BE_VALID_REGEX"
+	X_MUST_BE_GREATER_OR_TO_0              = "X_MUST_BE_GREATER_OR_TO_0"
+	X_CANNOT_BE_GREATER_THAN_Y             = "X_CANNOT_BE_GREATER_THAN_Y"
+	X_MUST_BE_STRICTLY_GREATER_THAN_0      = "X_MUST_BE_STRICTLY_GREATER_THAN_0"
+	X_CANNOT_BE_USED_WITHOUT_Y             = "X_CANNOT_BE_USED_WITHOUT_Y"
+	X_ITEMS_MUST_BE_UNIQUE                 = "X_ITEMS_MUST_BE_UNIQUE"
+	X_ITEMS_MUST_BE_TYPE_Y                 = "X_ITEMS_MUST_BE_TYPE_Y"
 )
 
 type Message struct {
@@ -71,66 +112,66 @@ func newMessageMaker(code, format string) messageMaker {
 }
 
 var (
-	ERROR_MESSAGE_X_IS_NOT_A_VALID_TYPE = newMessageMaker("X_IS_NOT_A_VALID_TYPE", `%s is not a valid type`)
+	ERROR_MESSAGE_X_IS_NOT_A_VALID_TYPE = newMessageMaker(X_IS_NOT_A_VALID_TYPE, `%s is not a valid type`)
 
-	ERROR_MESSAGE_X_TYPE_IS_DUPLICATED = newMessageMaker("X_TYPE_IS_DUPLICATED", `%s type is duplicated`)
+	ERROR_MESSAGE_X_TYPE_IS_DUPLICATED = newMessageMaker(X_TYPE_IS_DUPLICATED, `%s type is duplicated`)
 
-	ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y = newMessageMaker("X_MUST_BE_OF_TYPE_Y", `%s must be of type %s`)
+	ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y = newMessageMaker(X_MUST_BE_OF_TYPE_Y, `%s must be of type %s`)
 
-	ERROR_MESSAGE_X_MUST_BE_A_Y  = newMessageMaker("X_MUST_BE_A_Y", `%s must be of a %s`)
-	ERROR_MESSAGE_X_MUST_BE_AN_Y = newMessageMaker("X_MUST_BE_AN_Y", `%s must be of an %s`)
+	ERROR_MESSAGE_X_MUST_BE_A_Y  = newMessageMaker(X_MUST_BE_A_Y, `%s must be of a %s`)
+	ERROR_MESSAGE_X_MUST_BE_AN_Y = newMessageMaker(X_MUST_BE_AN_Y, `%s must be of an %s`)
 
-	ERROR_MESSAGE_X_IS_MISSING_AND_REQUIRED  = newMessageMaker("X_IS_MISSING_AND_REQUIRED", `%s is missing and required`)
-	ERROR_MESSAGE_MUST_BE_OF_TYPE_X          = newMessageMaker("MUST_BE_OF_TYPE_X", `must be of type %s`)
-	ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE     = newMessageMaker("X_ITEMS_MUST_BE_UNIQUE", `%s items must be unique`)
-	ERROR_MESSAGE_X_ITEMS_MUST_BE_TYPE_Y     = newMessageMaker("X_ITEMS_MUST_BE_TYPE_Y", `%s items must be %s`)
-	ERROR_MESSAGE_DOES_NOT_MATCH_PATTERN     = newMessageMaker("DOES_NOT_MATCH_PATTERN", `does not match pattern '%s'`)
-	ERROR_MESSAGE_MUST_MATCH_ONE_ENUM_VALUES = newMessageMaker("MUST_MATCH_ONE_ENUM_VALUES", `must match one of the enum values [%s]`)
+	ERROR_MESSAGE_X_IS_MISSING_AND_REQUIRED  = newMessageMaker(X_IS_MISSING_AND_REQUIRED, `%s is missing and required`)
+	ERROR_MESSAGE_MUST_BE_OF_TYPE_X          = newMessageMaker(MUST_BE_OF_TYPE_X, `must be of type %s`)
+	ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE     = newMessageMaker(X_ITEMS_MUST_BE_UNIQUE, `%s items must be unique`)
+	ERROR_MESSAGE_X_ITEMS_MUST_BE_TYPE_Y     = newMessageMaker(X_ITEMS_MUST_BE_TYPE_Y, `%s items must be %s`)
+	ERROR_MESSAGE_DOES_NOT_MATCH_PATTERN     = newMessageMaker(DOES_NOT_MATCH_PATTERN, `does not match pattern '%s'`)
+	ERROR_MESSAGE_MUST_MATCH_ONE_ENUM_VALUES = newMessageMaker(MUST_MATCH_ONE_ENUM_VALUES, `must match one of the enum values [%s]`)
 
-	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL = newMessageMaker("STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL", `string length must be greater or equal to %d`)
-	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL   = newMessageMaker("STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL", `string length must be lower or equal to %d`)
+	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL = newMessageMaker(STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL, `string length must be greater or equal to %d`)
+	ERROR_MESSAGE_STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL   = newMessageMaker(STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL, `string length must be lower or equal to %d`)
 
-	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER_OR_EQUAL   = newMessageMaker("NUMBER_MUST_BE_LOWER_OR_EQUAL", `must be lower than or equal to %s`)
-	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER            = newMessageMaker("NUMBER_MUST_BE_LOWER", `must be lower than %s`)
-	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER_OR_EQUAL = newMessageMaker("NUMBER_MUST_BE_GREATER_OR_EQUAL", `must be greater than or equal to %s`)
-	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER          = newMessageMaker("NUMBER_MUST_BE_GREATER", `must be greater than %s`)
+	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER_OR_EQUAL   = newMessageMaker(NUMBER_MUST_BE_LOWER_OR_EQUAL, `must be lower than or equal to %s`)
+	ERROR_MESSAGE_NUMBER_MUST_BE_LOWER            = newMessageMaker(NUMBER_MUST_BE_LOWER, `must be lower than %s`)
+	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER_OR_EQUAL = newMessageMaker(NUMBER_MUST_BE_GREATER_OR_EQUAL, `must be greater than or equal to %s`)
+	ERROR_MESSAGE_NUMBER_MUST_BE_GREATER          = newMessageMaker(NUMBER_MUST_BE_GREATER, `must be greater than %s`)
 
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ALLOF = newMessageMaker("NUMBER_MUST_VALIDATE_ALLOF", `must validate all the schemas (allOf)`)
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ONEOF = newMessageMaker("NUMBER_MUST_VALIDATE_ONEOF", `must validate one and only one schema (oneOf)`)
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ANYOF = newMessageMaker("NUMBER_MUST_VALIDATE_ANYOF", `must validate at least one schema (anyOf)`)
-	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_NOT   = newMessageMaker("NUMBER_MUST_VALIDATE_NOT", `must not validate the schema (not)`)
+	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ALLOF = newMessageMaker(NUMBER_MUST_VALIDATE_ALLOF, `must validate all the schemas (allOf)`)
+	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ONEOF = newMessageMaker(NUMBER_MUST_VALIDATE_ONEOF, `must validate one and only one schema (oneOf)`)
+	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ANYOF = newMessageMaker(NUMBER_MUST_VALIDATE_ANYOF, `must validate at least one schema (anyOf)`)
+	ERROR_MESSAGE_NUMBER_MUST_VALIDATE_NOT   = newMessageMaker(NUMBER_MUST_VALIDATE_NOT, `must not validate the schema (not)`)
 
-	ERROR_MESSAGE_ARRAY_MIN_ITEMS = newMessageMaker("ARRAY_MIN_ITEMS", `array must have at least %d items`)
-	ERROR_MESSAGE_ARRAY_MAX_ITEMS = newMessageMaker("ARRAY_MAX_ITEMS", `array must have at the most %d items`)
+	ERROR_MESSAGE_ARRAY_MIN_ITEMS = newMessageMaker(ARRAY_MIN_ITEMS, `array must have at least %d items`)
+	ERROR_MESSAGE_ARRAY_MAX_ITEMS = newMessageMaker(ARRAY_MAX_ITEMS, `array must have at the most %d items`)
 
-	ERROR_MESSAGE_ARRAY_MIN_PROPERTIES = newMessageMaker("ARRAY_MIN_PROPERTIES", `must have at least %d properties`)
-	ERROR_MESSAGE_ARRAY_MAX_PROPERTIES = newMessageMaker("ARRAY_MAX_PROPERTIES", `must have at the most %d properties`)
+	ERROR_MESSAGE_ARRAY_MIN_PROPERTIES = newMessageMaker(ARRAY_MIN_PROPERTIES, `must have at least %d properties`)
+	ERROR_MESSAGE_ARRAY_MAX_PROPERTIES = newMessageMaker(ARRAY_MAX_PROPERTIES, `must have at the most %d properties`)
 
-	ERROR_MESSAGE_HAS_DEPENDENCY_ON = newMessageMaker("HAS_DEPENDENCY_ON", `has a dependency on %s`)
+	ERROR_MESSAGE_HAS_DEPENDENCY_ON = newMessageMaker(HAS_DEPENDENCY_ON, `has a dependency on %s`)
 
-	ERROR_MESSAGE_MULTIPLE_OF = newMessageMaker("MULTIPLE_OF", `must be a multiple of %s`)
+	ERROR_MESSAGE_MULTIPLE_OF = newMessageMaker(MULTIPLE_OF, `must be a multiple of %s`)
 
-	ERROR_MESSAGE_ARRAY_NO_ADDITIONAL_ITEM = newMessageMaker("ARRAY_NO_ADDITIONAL_ITEM", `no additional item allowed on array`)
+	ERROR_MESSAGE_ARRAY_NO_ADDITIONAL_ITEM = newMessageMaker(ARRAY_NO_ADDITIONAL_ITEM, `no additional item allowed on array`)
 
-	ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED = newMessageMaker("ADDITIONAL_PROPERTY_NOT_ALLOWED", `additional property "%s" is not allowed`)
-	ERROR_MESSAGE_INVALID_PATTERN_PROPERTY        = newMessageMaker("INVALID_PATTERN_PROPERTY", `property "%s" does not match pattern %s`)
+	ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED = newMessageMaker(ADDITIONAL_PROPERTY_NOT_ALLOWED, `additional property "%s" is not allowed`)
+	ERROR_MESSAGE_INVALID_PATTERN_PROPERTY        = newMessageMaker(INVALID_PATTERN_PROPERTY, `property "%s" does not match pattern %s`)
 
-	ERROR_MESSAGE_INTERNAL = newMessageMaker("INTERNAL", `internal error %s`)
+	ERROR_MESSAGE_INTERNAL = newMessageMaker(INTERNAL, `internal error %s`)
 
-	ERROR_MESSAGE_GET_HTTP_BAD_STATUS = newMessageMaker("GET_HTTP_BAD_STATUS", `Could not read schema from HTTP, response status is %d`)
+	ERROR_MESSAGE_GET_HTTP_BAD_STATUS = newMessageMaker(GET_HTTP_BAD_STATUS, `Could not read schema from HTTP, response status is %d`)
 
-	ERROR_MESSAGE_NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT = newMessageMaker("NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT", `Invalid argument, must be a JSON string, a JSON reference string or a map[string]interface{}`)
+	ERROR_MESSAGE_NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT = newMessageMaker(NEW_SCHEMA_DOCUMENT_INVALID_ARGUMENT, `Invalid argument, must be a JSON string, a JSON reference string or a map[string]interface{}`)
 
-	ERROR_MESSAGE_INVALID_REGEX_PATTERN = newMessageMaker("INVALID_REGEX_PATTERN", `Invalid regex pattern '%s'`)
-	ERROR_MESSAGE_X_MUST_BE_VALID_REGEX = newMessageMaker("X_MUST_BE_VALID_REGEX", `%s must be a valid regex`)
+	ERROR_MESSAGE_INVALID_REGEX_PATTERN = newMessageMaker(INVALID_REGEX_PATTERN, `Invalid regex pattern '%s'`)
+	ERROR_MESSAGE_X_MUST_BE_VALID_REGEX = newMessageMaker(X_MUST_BE_VALID_REGEX, `%s must be a valid regex`)
 
-	ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0 = newMessageMaker("X_MUST_BE_GREATER_OR_TO_0", `%s must be greater than or equal to 0`)
+	ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0 = newMessageMaker(X_MUST_BE_GREATER_OR_TO_0, `%s must be greater than or equal to 0`)
 
-	ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y = newMessageMaker("X_CANNOT_BE_GREATER_THAN_Y", `%s cannot be greater than %s`)
+	ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y = newMessageMaker(X_CANNOT_BE_GREATER_THAN_Y, `%s cannot be greater than %s`)
 
-	ERROR_MESSAGE_X_MUST_BE_STRICTLY_GREATER_THAN_0 = newMessageMaker("X_MUST_BE_STRICTLY_GREATER_THAN_0", `%s must be strictly greater than 0`)
+	ERROR_MESSAGE_X_MUST_BE_STRICTLY_GREATER_THAN_0 = newMessageMaker(X_MUST_BE_STRICTLY_GREATER_THAN_0, `%s must be strictly greater than 0`)
 
-	ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y = newMessageMaker("X_CANNOT_BE_USED_WITHOUT_Y", `%s cannot be used without %s`)
+	ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y = newMessageMaker(X_CANNOT_BE_USED_WITHOUT_Y, `%s cannot be used without %s`)
 
-	ERROR_MESSAGE_REFERENCE_X_MUST_BE_CANONICAL = newMessageMaker("REFERENCE_X_MUST_BE_CANONICAL", `Reference %s must be canonical`)
+	ERROR_MESSAGE_REFERENCE_X_MUST_BE_CANONICAL = newMessageMaker(REFERENCE_X_MUST_BE_CANONICAL, `Reference %s must be canonical`)
 )

--- a/locales_test.go
+++ b/locales_test.go
@@ -1,0 +1,21 @@
+package gojsonschema
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var (
+	testMessageMaker = newMessageMaker("BASIC_ERROR", "%v %v")
+)
+
+func TestMessageMakerFormat(t *testing.T) {
+	message := testMessageMaker("one", "two")
+	assert.True(t, message.Description == "one two")
+}
+
+func TestMessageMakerError(t *testing.T) {
+	message := testMessageMaker("one", "two")
+	assert.True(t, message.Error() != nil)
+	assert.True(t, message.Error().Error() == "one two")
+}

--- a/result.go
+++ b/result.go
@@ -31,6 +31,7 @@ import (
 
 type ResultError struct {
 	Context     *jsonContext // Tree like notation of the part that failed the validation. ex (root).a.b ...
+	Code        string       // A code constant representing the error condition (use to build your own error messages instead of using Description)
 	Description string       // A human readable error message
 	Value       interface{}  // Value given by the JSON file that is the source of the error
 }
@@ -71,8 +72,8 @@ func (v *Result) Errors() []ResultError {
 	return v.errors
 }
 
-func (v *Result) addError(context *jsonContext, value interface{}, description string) {
-	v.errors = append(v.errors, ResultError{Context: context, Value: value, Description: description})
+func (v *Result) addError(context *jsonContext, value interface{}, description, code string) {
+	v.errors = append(v.errors, ResultError{Context: context, Value: value, Description: description, Code: code})
 	v.score -= 2 // results in a net -1 when added to the +1 we get at the end of the validation function
 }
 

--- a/schema.go
+++ b/schema.go
@@ -29,7 +29,6 @@ package gojsonschema
 import (
 	//	"encoding/json"
 	"errors"
-	"fmt"
 	"github.com/xeipuuv/gojsonreference"
 	"reflect"
 	"regexp"
@@ -64,7 +63,7 @@ func (d *Schema) SetRootSchemaName(name string) {
 func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema) error {
 
 	if !isKind(documentNode, reflect.Map) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, STRING_SCHEMA, TYPE_OBJECT))
+		return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(STRING_SCHEMA, TYPE_OBJECT).Error()
 	}
 
 	m := documentNode.(map[string]interface{})
@@ -76,7 +75,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	// $subSchema
 	if existsMapKey(m, KEY_SCHEMA) {
 		if !isKind(m[KEY_SCHEMA], reflect.String) {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_SCHEMA, TYPE_STRING))
+			return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_SCHEMA, TYPE_STRING).Error()
 		}
 		schemaRef := m[KEY_SCHEMA].(string)
 		schemaReference, err := gojsonreference.NewJsonReference(schemaRef)
@@ -88,7 +87,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 
 	// $ref
 	if existsMapKey(m, KEY_REF) && !isKind(m[KEY_REF], reflect.String) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_REF, TYPE_STRING))
+		return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_REF, TYPE_STRING).Error()
 	}
 	if k, ok := m[KEY_REF].(string); ok {
 
@@ -121,18 +120,17 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 						return errors.New(err.Error())
 					}
 				} else {
-					return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_DEFINITIONS, STRING_ARRAY_OF_SCHEMAS))
+					return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_DEFINITIONS, STRING_ARRAY_OF_SCHEMAS).Error()
 				}
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_DEFINITIONS, STRING_ARRAY_OF_SCHEMAS))
+			return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_DEFINITIONS, STRING_ARRAY_OF_SCHEMAS).Error()
 		}
-
 	}
 
 	// id
 	if existsMapKey(m, KEY_ID) && !isKind(m[KEY_ID], reflect.String) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_ID, TYPE_STRING))
+		return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_ID, TYPE_STRING).Error()
 	}
 	if k, ok := m[KEY_ID].(string); ok {
 		currentSchema.id = &k
@@ -140,7 +138,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 
 	// title
 	if existsMapKey(m, KEY_TITLE) && !isKind(m[KEY_TITLE], reflect.String) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_TITLE, TYPE_STRING))
+		return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_TITLE, TYPE_STRING).Error()
 	}
 	if k, ok := m[KEY_TITLE].(string); ok {
 		currentSchema.title = &k
@@ -148,7 +146,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 
 	// description
 	if existsMapKey(m, KEY_DESCRIPTION) && !isKind(m[KEY_DESCRIPTION], reflect.String) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_DESCRIPTION, TYPE_STRING))
+		return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_DESCRIPTION, TYPE_STRING).Error()
 	}
 	if k, ok := m[KEY_DESCRIPTION].(string); ok {
 		currentSchema.description = &k
@@ -168,14 +166,14 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				arrayOfTypes := m[KEY_TYPE].([]interface{})
 				for _, typeInArray := range arrayOfTypes {
 					if reflect.ValueOf(typeInArray).Kind() != reflect.String {
-						return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_TYPE, TYPE_STRING+"/"+STRING_ARRAY_OF_STRINGS))
+						return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_TYPE, TYPE_STRING+"/"+STRING_ARRAY_OF_STRINGS).Error()
 					} else {
 						currentSchema.types.Add(typeInArray.(string))
 					}
 				}
 
 			} else {
-				return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_TYPE, TYPE_STRING+"/"+STRING_ARRAY_OF_STRINGS))
+				return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_TYPE, TYPE_STRING+"/"+STRING_ARRAY_OF_STRINGS).Error()
 			}
 		}
 	}
@@ -200,7 +198,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				return errors.New(err.Error())
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_ADDITIONAL_PROPERTIES, TYPE_BOOLEAN+"/"+STRING_SCHEMA))
+			return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_ADDITIONAL_PROPERTIES, TYPE_BOOLEAN+"/"+STRING_SCHEMA).Error()
 		}
 	}
 
@@ -213,7 +211,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				for k, v := range patternPropertiesMap {
 					_, err := regexp.MatchString(k, "")
 					if err != nil {
-						return errors.New(fmt.Sprintf(ERROR_MESSAGE_INVALID_REGEX_PATTERN, k))
+						return ERROR_MESSAGE_INVALID_REGEX_PATTERN(k).Error()
 					}
 					newSchema := &subSchema{property: k, parent: currentSchema, ref: currentSchema.ref}
 					err = d.parseSchema(v, newSchema)
@@ -224,7 +222,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				}
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_PATTERN_PROPERTIES, STRING_SCHEMA))
+			return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_PATTERN_PROPERTIES, STRING_SCHEMA).Error()
 		}
 	}
 
@@ -249,7 +247,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 						return err
 					}
 				} else {
-					return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_ITEMS, STRING_SCHEMA+"/"+STRING_ARRAY_OF_SCHEMAS))
+					return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_ITEMS, STRING_SCHEMA+"/"+STRING_ARRAY_OF_SCHEMAS).Error()
 				}
 				currentSchema.itemsChildrenIsSingleSchema = false
 			}
@@ -263,7 +261,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 			}
 			currentSchema.itemsChildrenIsSingleSchema = true
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_ITEMS, STRING_SCHEMA+"/"+STRING_ARRAY_OF_SCHEMAS))
+			return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_ITEMS, STRING_SCHEMA+"/"+STRING_ARRAY_OF_SCHEMAS).Error()
 		}
 	}
 
@@ -279,7 +277,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				return errors.New(err.Error())
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_ADDITIONAL_ITEMS, TYPE_BOOLEAN+"/"+STRING_SCHEMA))
+			return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_ADDITIONAL_ITEMS, TYPE_BOOLEAN+"/"+STRING_SCHEMA).Error()
 		}
 	}
 
@@ -288,10 +286,10 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_MULTIPLE_OF) {
 		multipleOfValue := mustBeNumber(m[KEY_MULTIPLE_OF])
 		if multipleOfValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_A_Y, KEY_MULTIPLE_OF, STRING_NUMBER))
+			return ERROR_MESSAGE_X_MUST_BE_A_Y(KEY_MULTIPLE_OF, STRING_NUMBER).Error()
 		}
 		if *multipleOfValue <= 0 {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_STRICTLY_GREATER_THAN_0, KEY_MULTIPLE_OF))
+			return ERROR_MESSAGE_X_MUST_BE_STRICTLY_GREATER_THAN_0(KEY_MULTIPLE_OF).Error()
 		}
 		currentSchema.multipleOf = multipleOfValue
 	}
@@ -299,7 +297,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_MINIMUM) {
 		minimumValue := mustBeNumber(m[KEY_MINIMUM])
 		if minimumValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_A_Y, KEY_MINIMUM, STRING_NUMBER))
+			return ERROR_MESSAGE_X_MUST_BE_A_Y(KEY_MINIMUM, STRING_NUMBER).Error()
 		}
 		currentSchema.minimum = minimumValue
 	}
@@ -307,19 +305,19 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_EXCLUSIVE_MINIMUM) {
 		if isKind(m[KEY_EXCLUSIVE_MINIMUM], reflect.Bool) {
 			if currentSchema.minimum == nil {
-				return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y, KEY_EXCLUSIVE_MINIMUM, KEY_MINIMUM))
+				return ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y(KEY_EXCLUSIVE_MINIMUM, KEY_MINIMUM).Error()
 			}
 			exclusiveMinimumValue := m[KEY_EXCLUSIVE_MINIMUM].(bool)
 			currentSchema.exclusiveMinimum = exclusiveMinimumValue
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_A_Y, KEY_EXCLUSIVE_MINIMUM, TYPE_BOOLEAN))
+			return ERROR_MESSAGE_X_MUST_BE_A_Y(KEY_EXCLUSIVE_MINIMUM, TYPE_BOOLEAN).Error()
 		}
 	}
 
 	if existsMapKey(m, KEY_MAXIMUM) {
 		maximumValue := mustBeNumber(m[KEY_MAXIMUM])
 		if maximumValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_A_Y, KEY_MAXIMUM, STRING_NUMBER))
+			return ERROR_MESSAGE_X_MUST_BE_A_Y(KEY_MAXIMUM, STRING_NUMBER).Error()
 		}
 		currentSchema.maximum = maximumValue
 	}
@@ -327,18 +325,18 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_EXCLUSIVE_MAXIMUM) {
 		if isKind(m[KEY_EXCLUSIVE_MAXIMUM], reflect.Bool) {
 			if currentSchema.maximum == nil {
-				return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y, KEY_EXCLUSIVE_MAXIMUM, KEY_MAXIMUM))
+				return ERROR_MESSAGE_X_CANNOT_BE_USED_WITHOUT_Y(KEY_EXCLUSIVE_MAXIMUM, KEY_MAXIMUM).Error()
 			}
 			exclusiveMaximumValue := m[KEY_EXCLUSIVE_MAXIMUM].(bool)
 			currentSchema.exclusiveMaximum = exclusiveMaximumValue
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_A_Y, KEY_EXCLUSIVE_MAXIMUM, STRING_NUMBER))
+			return ERROR_MESSAGE_X_MUST_BE_A_Y(KEY_EXCLUSIVE_MAXIMUM, STRING_NUMBER).Error()
 		}
 	}
 
 	if currentSchema.minimum != nil && currentSchema.maximum != nil {
 		if *currentSchema.minimum > *currentSchema.maximum {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y, KEY_MINIMUM, KEY_MAXIMUM))
+			return ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y(KEY_MINIMUM, KEY_MAXIMUM).Error()
 		}
 	}
 
@@ -347,10 +345,10 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_MIN_LENGTH) {
 		minLengthIntegerValue := mustBeInteger(m[KEY_MIN_LENGTH])
 		if minLengthIntegerValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_MIN_LENGTH, TYPE_INTEGER))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_MIN_LENGTH, TYPE_INTEGER).Error()
 		}
 		if *minLengthIntegerValue < 0 {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0, KEY_MIN_LENGTH))
+			return ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0(KEY_MIN_LENGTH).Error()
 		}
 		currentSchema.minLength = minLengthIntegerValue
 	}
@@ -358,17 +356,19 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_MAX_LENGTH) {
 		maxLengthIntegerValue := mustBeInteger(m[KEY_MAX_LENGTH])
 		if maxLengthIntegerValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_MAX_LENGTH, TYPE_INTEGER))
+
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_MAX_LENGTH, TYPE_INTEGER).Error()
 		}
 		if *maxLengthIntegerValue < 0 {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0, KEY_MAX_LENGTH))
+
+			return ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0(KEY_MAX_LENGTH).Error()
 		}
 		currentSchema.maxLength = maxLengthIntegerValue
 	}
 
 	if currentSchema.minLength != nil && currentSchema.maxLength != nil {
 		if *currentSchema.minLength > *currentSchema.maxLength {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y, KEY_MIN_LENGTH, KEY_MAX_LENGTH))
+			return ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y(KEY_MIN_LENGTH, KEY_MAX_LENGTH).Error()
 		}
 	}
 
@@ -376,11 +376,11 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 		if isKind(m[KEY_PATTERN], reflect.String) {
 			regexpObject, err := regexp.Compile(m[KEY_PATTERN].(string))
 			if err != nil {
-				return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_VALID_REGEX, KEY_PATTERN))
+				return ERROR_MESSAGE_X_MUST_BE_VALID_REGEX(KEY_PATTERN).Error()
 			}
 			currentSchema.pattern = regexpObject
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_A_Y, KEY_PATTERN, TYPE_STRING))
+			return ERROR_MESSAGE_X_MUST_BE_A_Y(KEY_PATTERN, TYPE_STRING).Error()
 		}
 	}
 
@@ -389,10 +389,10 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_MIN_PROPERTIES) {
 		minPropertiesIntegerValue := mustBeInteger(m[KEY_MIN_PROPERTIES])
 		if minPropertiesIntegerValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_MIN_PROPERTIES, TYPE_INTEGER))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_MIN_PROPERTIES, TYPE_INTEGER).Error()
 		}
 		if *minPropertiesIntegerValue < 0 {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0, KEY_MIN_PROPERTIES))
+			return ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0(KEY_MIN_PROPERTIES).Error()
 		}
 		currentSchema.minProperties = minPropertiesIntegerValue
 	}
@@ -400,17 +400,17 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_MAX_PROPERTIES) {
 		maxPropertiesIntegerValue := mustBeInteger(m[KEY_MAX_PROPERTIES])
 		if maxPropertiesIntegerValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_MAX_PROPERTIES, TYPE_INTEGER))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_MAX_PROPERTIES, TYPE_INTEGER).Error()
 		}
 		if *maxPropertiesIntegerValue < 0 {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0, KEY_MAX_PROPERTIES))
+			return ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0(KEY_MAX_PROPERTIES).Error()
 		}
 		currentSchema.maxProperties = maxPropertiesIntegerValue
 	}
 
 	if currentSchema.minProperties != nil && currentSchema.maxProperties != nil {
 		if *currentSchema.minProperties > *currentSchema.maxProperties {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y, KEY_MIN_PROPERTIES, KEY_MAX_PROPERTIES))
+			return ERROR_MESSAGE_X_CANNOT_BE_GREATER_THAN_Y(KEY_MIN_PROPERTIES, KEY_MAX_PROPERTIES).Error()
 		}
 	}
 
@@ -424,11 +424,12 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 						return err
 					}
 				} else {
-					return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_ITEMS_MUST_BE_TYPE_Y, KEY_REQUIRED, TYPE_STRING))
+					return ERROR_MESSAGE_X_ITEMS_MUST_BE_TYPE_Y(KEY_REQUIRED, TYPE_STRING).Error()
 				}
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_REQUIRED, TYPE_ARRAY))
+
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_REQUIRED, TYPE_ARRAY).Error()
 		}
 	}
 
@@ -437,10 +438,10 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_MIN_ITEMS) {
 		minItemsIntegerValue := mustBeInteger(m[KEY_MIN_ITEMS])
 		if minItemsIntegerValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_MIN_ITEMS, TYPE_INTEGER))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_MIN_ITEMS, TYPE_INTEGER).Error()
 		}
 		if *minItemsIntegerValue < 0 {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0, KEY_MIN_ITEMS))
+			return ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0(KEY_MIN_ITEMS).Error()
 		}
 		currentSchema.minItems = minItemsIntegerValue
 	}
@@ -448,10 +449,10 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	if existsMapKey(m, KEY_MAX_ITEMS) {
 		maxItemsIntegerValue := mustBeInteger(m[KEY_MAX_ITEMS])
 		if maxItemsIntegerValue == nil {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_MAX_ITEMS, TYPE_INTEGER))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_MAX_ITEMS, TYPE_INTEGER).Error()
 		}
 		if *maxItemsIntegerValue < 0 {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0, KEY_MAX_ITEMS))
+			return ERROR_MESSAGE_X_MUST_BE_GREATER_OR_TO_0(KEY_MAX_ITEMS).Error()
 		}
 		currentSchema.maxItems = maxItemsIntegerValue
 	}
@@ -460,7 +461,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 		if isKind(m[KEY_UNIQUE_ITEMS], reflect.Bool) {
 			currentSchema.uniqueItems = m[KEY_UNIQUE_ITEMS].(bool)
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_A_Y, KEY_UNIQUE_ITEMS, TYPE_BOOLEAN))
+			return ERROR_MESSAGE_X_MUST_BE_A_Y(KEY_UNIQUE_ITEMS, TYPE_BOOLEAN).Error()
 		}
 	}
 
@@ -475,7 +476,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				}
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_ENUM, TYPE_ARRAY))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_ENUM, TYPE_ARRAY).Error()
 		}
 	}
 
@@ -492,7 +493,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				}
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_ONE_OF, TYPE_ARRAY))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_ONE_OF, TYPE_ARRAY).Error()
 		}
 	}
 
@@ -507,7 +508,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				}
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_ANY_OF, TYPE_ARRAY))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_ANY_OF, TYPE_ARRAY).Error()
 		}
 	}
 
@@ -522,7 +523,8 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				}
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_ANY_OF, TYPE_ARRAY))
+
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_ANY_OF, TYPE_ARRAY).Error()
 		}
 	}
 
@@ -535,7 +537,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				return err
 			}
 		} else {
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_AN_Y, KEY_NOT, TYPE_OBJECT))
+			return ERROR_MESSAGE_X_MUST_BE_AN_Y(KEY_NOT, TYPE_OBJECT).Error()
 		}
 	}
 
@@ -591,7 +593,7 @@ func (d *Schema) parseReference(documentNode interface{}, currentSchema *subSche
 	}
 
 	if !isKind(refdDocumentNode, reflect.Map) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, STRING_SCHEMA, TYPE_OBJECT))
+		return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(STRING_SCHEMA, TYPE_OBJECT).Error()
 	}
 
 	// returns the loaded referenced subSchema for the caller to update its current subSchema
@@ -614,7 +616,7 @@ func (d *Schema) parseReference(documentNode interface{}, currentSchema *subSche
 func (d *Schema) parseProperties(documentNode interface{}, currentSchema *subSchema) error {
 
 	if !isKind(documentNode, reflect.Map) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, STRING_PROPERTIES, TYPE_OBJECT))
+		return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(STRING_PROPERTIES, TYPE_OBJECT).Error()
 	}
 
 	m := documentNode.(map[string]interface{})
@@ -634,7 +636,7 @@ func (d *Schema) parseProperties(documentNode interface{}, currentSchema *subSch
 func (d *Schema) parseDependencies(documentNode interface{}, currentSchema *subSchema) error {
 
 	if !isKind(documentNode, reflect.Map) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, KEY_DEPENDENCIES, TYPE_OBJECT))
+		return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(KEY_DEPENDENCIES, TYPE_OBJECT).Error()
 	}
 
 	m := documentNode.(map[string]interface{})
@@ -649,7 +651,7 @@ func (d *Schema) parseDependencies(documentNode interface{}, currentSchema *subS
 
 			for _, value := range values {
 				if !isKind(value, reflect.String) {
-					return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, STRING_DEPENDENCY, STRING_SCHEMA_OR_ARRAY_OF_STRINGS))
+					return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(STRING_DEPENDENCY, STRING_SCHEMA_OR_ARRAY_OF_STRINGS).Error()
 				} else {
 					valuesToRegister = append(valuesToRegister, value.(string))
 				}
@@ -665,7 +667,7 @@ func (d *Schema) parseDependencies(documentNode interface{}, currentSchema *subS
 			currentSchema.dependencies[k] = depSchema
 
 		default:
-			return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y, STRING_DEPENDENCY, STRING_SCHEMA_OR_ARRAY_OF_STRINGS))
+			return ERROR_MESSAGE_X_MUST_BE_OF_TYPE_Y(STRING_DEPENDENCY, STRING_SCHEMA_OR_ARRAY_OF_STRINGS).Error()
 		}
 
 	}

--- a/schemaPool.go
+++ b/schemaPool.go
@@ -27,8 +27,6 @@
 package gojsonschema
 
 import (
-	"errors"
-	"fmt"
 	"github.com/xeipuuv/gojsonreference"
 )
 
@@ -66,7 +64,7 @@ func (p *schemaPool) GetDocument(reference gojsonreference.JsonReference) (*sche
 
 	// It is not possible to load anything that is not canonical...
 	if !reference.IsCanonical() {
-		return nil, errors.New(fmt.Sprintf(ERROR_MESSAGE_REFERENCE_X_MUST_BE_CANONICAL, reference))
+		return nil, ERROR_MESSAGE_REFERENCE_X_MUST_BE_CANONICAL(reference).Error()
 	}
 
 	refToUrl := reference

--- a/schemaType.go
+++ b/schemaType.go
@@ -26,7 +26,6 @@
 package gojsonschema
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 )
@@ -44,11 +43,11 @@ func (t *jsonSchemaType) IsTyped() bool {
 func (t *jsonSchemaType) Add(etype string) error {
 
 	if !isStringInSlice(JSON_TYPES, etype) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_IS_NOT_A_VALID_TYPE, etype))
+		return ERROR_MESSAGE_X_IS_NOT_A_VALID_TYPE(etype).Error()
 	}
 
 	if t.Contains(etype) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_TYPE_IS_DUPLICATED, etype))
+		return ERROR_MESSAGE_X_TYPE_IS_DUPLICATED(etype).Error()
 	}
 
 	t.types = append(t.types, etype)

--- a/subSchema.go
+++ b/subSchema.go
@@ -27,8 +27,6 @@
 package gojsonschema
 
 import (
-	"errors"
-	"fmt"
 	"github.com/xeipuuv/gojsonreference"
 	"regexp"
 	"strings"
@@ -142,7 +140,7 @@ func (s *subSchema) AddEnum(i interface{}) error {
 	}
 
 	if isStringInSlice(s.enum, *is) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE, KEY_ENUM))
+		return ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE(KEY_ENUM).Error()
 	}
 
 	s.enum = append(s.enum, *is)
@@ -179,7 +177,7 @@ func (s *subSchema) SetNot(subSchema *subSchema) {
 func (s *subSchema) AddRequired(value string) error {
 
 	if isStringInSlice(s.required, value) {
-		return errors.New(fmt.Sprintf(ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE, KEY_REQUIRED))
+		return ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE(KEY_REQUIRED).Error()
 	}
 
 	s.required = append(s.required, value)

--- a/validation.go
+++ b/validation.go
@@ -26,7 +26,6 @@
 package gojsonschema
 
 import (
-	"fmt"
 	"reflect"
 	"regexp"
 	"strconv"
@@ -92,7 +91,8 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 	if currentNode == nil {
 
 		if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_NULL) {
-			result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+			message := ERROR_MESSAGE_MUST_BE_OF_TYPE_X(currentSubSchema.types.String())
+			result.addError(context, currentNode, message.Description, message.Code)
 			return
 		}
 
@@ -111,7 +111,8 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 		case reflect.Slice:
 
 			if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_ARRAY) {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				message := ERROR_MESSAGE_MUST_BE_OF_TYPE_X(currentSubSchema.types.String())
+				result.addError(context, currentNode, message.Description, message.Code)
 				return
 			}
 
@@ -126,7 +127,8 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 
 		case reflect.Map:
 			if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_OBJECT) {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				message := ERROR_MESSAGE_MUST_BE_OF_TYPE_X(currentSubSchema.types.String())
+				result.addError(context, currentNode, message.Description, message.Code)
 				return
 			}
 
@@ -153,7 +155,8 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 		case reflect.Bool:
 
 			if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_BOOLEAN) {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				message := ERROR_MESSAGE_MUST_BE_OF_TYPE_X(currentSubSchema.types.String())
+				result.addError(context, currentNode, message.Description, message.Code)
 				return
 			}
 
@@ -167,7 +170,8 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 		case reflect.String:
 
 			if currentSubSchema.types.IsTyped() && !currentSubSchema.types.Contains(TYPE_STRING) {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				message := ERROR_MESSAGE_MUST_BE_OF_TYPE_X(currentSubSchema.types.String())
+				result.addError(context, currentNode, message.Description, message.Code)
 				return
 			}
 
@@ -189,7 +193,8 @@ func (v *subSchema) validateRecursive(currentSubSchema *subSchema, currentNode i
 			validType := currentSubSchema.types.Contains(TYPE_NUMBER) || (isInteger && currentSubSchema.types.Contains(TYPE_INTEGER))
 
 			if currentSubSchema.types.IsTyped() && !validType {
-				result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_MUST_BE_OF_TYPE_X, currentSubSchema.types.String()))
+				message := ERROR_MESSAGE_MUST_BE_OF_TYPE_X(currentSubSchema.types.String())
+				result.addError(context, currentNode, message.Description, message.Code)
 				return
 			}
 
@@ -225,8 +230,8 @@ func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode inte
 			}
 		}
 		if !validatedAnyOf {
-
-			result.addError(context, currentNode, ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ANYOF)
+			message := ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ANYOF()
+			result.addError(context, currentNode, message.Description, message.Code)
 
 			if bestValidationResult != nil {
 				// add error messages of closest matching subSchema as
@@ -251,8 +256,8 @@ func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode inte
 		}
 
 		if nbValidated != 1 {
-
-			result.addError(context, currentNode, ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ONEOF)
+			message := ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ONEOF()
+			result.addError(context, currentNode, message.Description, message.Code)
 
 			if nbValidated == 0 {
 				// add error messages of closest matching subSchema as
@@ -275,14 +280,16 @@ func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode inte
 		}
 
 		if nbValidated != len(currentSubSchema.allOf) {
-			result.addError(context, currentNode, ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ALLOF)
+			message := ERROR_MESSAGE_NUMBER_MUST_VALIDATE_ALLOF()
+			result.addError(context, currentNode, message.Description, message.Code)
 		}
 	}
 
 	if currentSubSchema.not != nil {
 		validationResult := currentSubSchema.not.subValidateWithContext(currentNode, context)
 		if validationResult.Valid() {
-			result.addError(context, currentNode, ERROR_MESSAGE_NUMBER_MUST_VALIDATE_NOT)
+			message := ERROR_MESSAGE_NUMBER_MUST_VALIDATE_NOT()
+			result.addError(context, currentNode, message.Description, message.Code)
 		}
 	}
 
@@ -295,7 +302,8 @@ func (v *subSchema) validateSchema(currentSubSchema *subSchema, currentNode inte
 					case []string:
 						for _, dependOnKey := range dependency {
 							if _, dependencyResolved := currentNode.(map[string]interface{})[dependOnKey]; !dependencyResolved {
-								result.addError(context, currentNode, fmt.Sprintf(ERROR_MESSAGE_HAS_DEPENDENCY_ON, dependOnKey))
+								message := ERROR_MESSAGE_HAS_DEPENDENCY_ON(dependOnKey)
+								result.addError(context, currentNode, message.Description, message.Code)
 							}
 						}
 
@@ -320,10 +328,12 @@ func (v *subSchema) validateCommon(currentSubSchema *subSchema, value interface{
 	if len(currentSubSchema.enum) > 0 {
 		has, err := currentSubSchema.ContainsEnum(value)
 		if err != nil {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_INTERNAL, err))
+			message := ERROR_MESSAGE_INTERNAL(err)
+			result.addError(context, value, message.Description, message.Code)
 		}
 		if !has {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_MUST_MATCH_ONE_ENUM_VALUES, strings.Join(currentSubSchema.enum, ",")))
+			message := ERROR_MESSAGE_MUST_MATCH_ONE_ENUM_VALUES(strings.Join(currentSubSchema.enum, ","))
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 
@@ -360,7 +370,8 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 				switch currentSubSchema.additionalItems.(type) {
 				case bool:
 					if !currentSubSchema.additionalItems.(bool) {
-						result.addError(context, value, ERROR_MESSAGE_ARRAY_NO_ADDITIONAL_ITEM)
+						message := ERROR_MESSAGE_ARRAY_NO_ADDITIONAL_ITEM()
+						result.addError(context, value, message.Description, message.Code)
 					}
 				case *subSchema:
 					additionalItemSchema := currentSubSchema.additionalItems.(*subSchema)
@@ -377,12 +388,14 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 	// minItems & maxItems
 	if currentSubSchema.minItems != nil {
 		if nbItems < *currentSubSchema.minItems {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ARRAY_MIN_ITEMS, *currentSubSchema.minItems))
+			message := ERROR_MESSAGE_ARRAY_MIN_ITEMS(*currentSubSchema.minItems)
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 	if currentSubSchema.maxItems != nil {
 		if nbItems > *currentSubSchema.maxItems {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ARRAY_MAX_ITEMS, *currentSubSchema.maxItems))
+			message := ERROR_MESSAGE_ARRAY_MAX_ITEMS(*currentSubSchema.maxItems)
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 
@@ -392,10 +405,12 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 		for _, v := range value {
 			vString, err := marshalToJsonString(v)
 			if err != nil {
-				result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_INTERNAL, err))
+				message := ERROR_MESSAGE_INTERNAL(err)
+				result.addError(context, value, message.Description, message.Code)
 			}
 			if isStringInSlice(stringifiedItems, *vString) {
-				result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE, TYPE_ARRAY))
+				message := ERROR_MESSAGE_X_ITEMS_MUST_BE_UNIQUE(TYPE_ARRAY)
+				result.addError(context, value, message.Description, message.Code)
 			}
 			stringifiedItems = append(stringifiedItems, *vString)
 		}
@@ -412,12 +427,14 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 	// minProperties & maxProperties:
 	if currentSubSchema.minProperties != nil {
 		if len(value) < *currentSubSchema.minProperties {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ARRAY_MIN_PROPERTIES, *currentSubSchema.minProperties))
+			message := ERROR_MESSAGE_ARRAY_MIN_PROPERTIES(*currentSubSchema.minProperties)
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 	if currentSubSchema.maxProperties != nil {
 		if len(value) > *currentSubSchema.maxProperties {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ARRAY_MAX_PROPERTIES, *currentSubSchema.maxProperties))
+			message := ERROR_MESSAGE_ARRAY_MAX_PROPERTIES(*currentSubSchema.maxProperties)
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 
@@ -427,7 +444,8 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 		if ok {
 			result.incrementScore()
 		} else {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_X_IS_MISSING_AND_REQUIRED, fmt.Sprintf(`"%s" %s`, requiredProperty, STRING_PROPERTY)))
+			message := ERROR_MESSAGE_X_IS_MISSING_AND_REQUIRED(requiredProperty, STRING_PROPERTY)
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 
@@ -453,15 +471,16 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 					if found {
 
 						if pp_has && !pp_match {
-							result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED, pk))
+							message := ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED(pk)
+							result.addError(context, value, message.Description, message.Code)
 						}
 
 					} else {
 
 						if !pp_has || !pp_match {
-							result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED, pk))
+							message := ERROR_MESSAGE_ADDITIONAL_PROPERTY_NOT_ALLOWED(pk)
+							result.addError(context, value, message.Description, message.Code)
 						}
-
 					}
 				}
 			}
@@ -505,10 +524,9 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 			pp_has, pp_match := v.validatePatternProperty(currentSubSchema, pk, value[pk], result, context)
 
 			if pp_has && !pp_match {
-
-				result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_INVALID_PATTERN_PROPERTY, pk, currentSubSchema.PatternPropertiesString()))
+				message := ERROR_MESSAGE_INVALID_PATTERN_PROPERTY(pk, currentSubSchema.PatternPropertiesString())
+				result.addError(context, value, message.Description, message.Code)
 			}
-
 		}
 	}
 
@@ -560,20 +578,22 @@ func (v *subSchema) validateString(currentSubSchema *subSchema, value interface{
 	// minLength & maxLength:
 	if currentSubSchema.minLength != nil {
 		if utf8.RuneCount([]byte(stringValue)) < *currentSubSchema.minLength {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL, *currentSubSchema.minLength))
+			message := ERROR_MESSAGE_STRING_LENGTH_MUST_BE_GREATER_OR_EQUAL(*currentSubSchema.minLength)
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 	if currentSubSchema.maxLength != nil {
 		if utf8.RuneCount([]byte(stringValue)) > *currentSubSchema.maxLength {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL, *currentSubSchema.maxLength))
+			message := ERROR_MESSAGE_STRING_LENGTH_MUST_BE_LOWER_OR_EQUAL(*currentSubSchema.maxLength)
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 
 	// pattern:
 	if currentSubSchema.pattern != nil {
 		if !currentSubSchema.pattern.MatchString(stringValue) {
-			result.addError(context, value, fmt.Sprintf(ERROR_MESSAGE_DOES_NOT_MATCH_PATTERN, currentSubSchema.pattern))
-
+			message := ERROR_MESSAGE_DOES_NOT_MATCH_PATTERN(currentSubSchema.pattern)
+			result.addError(context, value, message.Description, message.Code)
 		}
 	}
 
@@ -595,7 +615,8 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 	// multipleOf:
 	if currentSubSchema.multipleOf != nil {
 		if !isFloat64AnInteger(float64Value / *currentSubSchema.multipleOf) {
-			result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_MULTIPLE_OF, resultErrorFormatNumber(*currentSubSchema.multipleOf)))
+			message := ERROR_MESSAGE_MULTIPLE_OF(resultErrorFormatNumber(*currentSubSchema.multipleOf))
+			result.addError(context, resultErrorFormatNumber(float64Value), message.Description, message.Code)
 		}
 	}
 
@@ -603,11 +624,13 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 	if currentSubSchema.maximum != nil {
 		if currentSubSchema.exclusiveMaximum {
 			if float64Value >= *currentSubSchema.maximum {
-				result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_NUMBER_MUST_BE_LOWER_OR_EQUAL, resultErrorFormatNumber(*currentSubSchema.maximum)))
+				message := ERROR_MESSAGE_NUMBER_MUST_BE_LOWER_OR_EQUAL(resultErrorFormatNumber(*currentSubSchema.maximum))
+				result.addError(context, resultErrorFormatNumber(float64Value), message.Description, message.Code)
 			}
 		} else {
 			if float64Value > *currentSubSchema.maximum {
-				result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_NUMBER_MUST_BE_LOWER, resultErrorFormatNumber(*currentSubSchema.maximum)))
+				message := ERROR_MESSAGE_NUMBER_MUST_BE_LOWER(resultErrorFormatNumber(*currentSubSchema.maximum))
+				result.addError(context, resultErrorFormatNumber(float64Value), message.Description, message.Code)
 			}
 		}
 	}
@@ -616,11 +639,13 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 	if currentSubSchema.minimum != nil {
 		if currentSubSchema.exclusiveMinimum {
 			if float64Value <= *currentSubSchema.minimum {
-				result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_NUMBER_MUST_BE_GREATER_OR_EQUAL, resultErrorFormatNumber(*currentSubSchema.minimum)))
+				message := ERROR_MESSAGE_NUMBER_MUST_BE_GREATER_OR_EQUAL(resultErrorFormatNumber(*currentSubSchema.minimum))
+				result.addError(context, resultErrorFormatNumber(float64Value), message.Description, message.Code)
 			}
 		} else {
 			if float64Value < *currentSubSchema.minimum {
-				result.addError(context, resultErrorFormatNumber(float64Value), fmt.Sprintf(ERROR_MESSAGE_NUMBER_MUST_BE_GREATER, resultErrorFormatNumber(*currentSubSchema.minimum)))
+				message := ERROR_MESSAGE_NUMBER_MUST_BE_GREATER(resultErrorFormatNumber(*currentSubSchema.minimum))
+				result.addError(context, resultErrorFormatNumber(float64Value), message.Description, message.Code)
 			}
 		}
 	}


### PR DESCRIPTION
…l for each error. This allows custom error messages from the client.

* Add the Message struct to locale.go. Message models the code and description of each error.
* Add the messageMaker func to locale.go. MessageMakers are closures that use error specification information (code and format string) to produce a Message.
* Refactor all of the places that used errors to work with messageMakers instead.