### PR TITLE
Extra character trim bugfix

### DIFF
--- a/result.go
+++ b/result.go
@@ -78,7 +78,7 @@ func (v *ResultErrorFields) Field() string {
 		}
 	}
 
-	return strings.TrimLeft(v.context.String(), STRING_ROOT_SCHEMA_PROPERTY+".")
+	return strings.TrimPrefix(v.context.String(), STRING_ROOT_SCHEMA_PROPERTY+".")
 }
 
 func (v *ResultErrorFields) SetType(errorType string) {


### PR DESCRIPTION
# Problem
Sometimes `Field()` in `ResultErrorFields` trims few char to much, it is because:

```go
return strings.TrimLeft(v.context.String(), STRING_ROOT_SCHEMA_PROPERTY+".")
```
according to [golang `strings.TrimLeft` documentation](http://golang.org/pkg/strings/#TrimLeft) is trimming all characters (not a prefix as expected) from string given as second argument.

E.g. Calling
```go
strings.TrimLeft("(root).regex", "(root).")
```
will return `"egex"`.

# Solution
Just replace `strings.TrimLeft` with `strings.TrimPrefix`.