### PR TITLE
Add support for "uuid" format

### DIFF
--- a/format_checkers.go
+++ b/format_checkers.go
@@ -56,6 +56,9 @@ type (
 
 	// HostnameFormatChecker validates a hostname is in the correct format
 	HostnameFormatChecker struct{}
+
+	// UUIDFormatChecker validates a UUID is in the correct format
+	UUIDFormatChecker struct{}
 )
 
 var (
@@ -69,6 +72,7 @@ var (
 			"ipv4":      IPV4FormatChecker{},
 			"ipv6":      IPV6FormatChecker{},
 			"uri":       URIFormatChecker{},
+			"uuid":      UUIDFormatChecker{},
 		},
 	}
 
@@ -77,6 +81,8 @@ var (
 
 	// Regex credit: https://www.socketloop.com/tutorials/golang-validate-hostname
 	rxHostname = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
+
+	rxUUID = regexp.MustCompile("^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$")
 )
 
 // Add adds a FormatChecker to the FormatCheckerChain
@@ -164,4 +170,8 @@ func (f URIFormatChecker) IsFormat(input string) bool {
 
 func (f HostnameFormatChecker) IsFormat(input string) bool {
 	return rxHostname.MatchString(input)
+}
+
+func (f UUIDFormatChecker) IsFormat(input string) bool {
+	return rxUUID.MatchString(input)
 }

--- a/format_checkers_test.go
+++ b/format_checkers_test.go
@@ -1,0 +1,16 @@
+package gojsonschema
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUUIDFormatCheckerIsFormat(t *testing.T) {
+	checker := UUIDFormatChecker{}
+
+	assert.True(t, checker.IsFormat("01234567-89ab-cdef-0123-456789abcdef"))
+	assert.True(t, checker.IsFormat("f1234567-89ab-cdef-0123-456789abcdef"))
+
+	assert.False(t, checker.IsFormat("not-a-uuid"))
+	assert.False(t, checker.IsFormat("g1234567-89ab-cdef-0123-456789abcdef"))
+}


### PR DESCRIPTION
Adds support for the "uuid" format, which notably is not in the JSON Schema core specification.

I wanted to get your reading on bringing in a format which is not in the list of defined attributes. [The specification][specification] has this to say about custom format attributes:

> Implementations MAY add custom format attributes. Save for agreement between parties, schema authors SHALL NOT expect a peer implementation to support this keyword and/or custom format attributes.

I understand that this can be a fine line in that you can start bringing in too many custom formats which can lead to bloat, but I think that UUIDs may be ubiquitous enough that this will be useful to a variety of different parties. One anecdote: at Heroku, missing the "uuid" format is the only reason that we can't validate objects according to our schema with gojsonschema out of the box.

[specification]: http://json-schema.org/latest/json-schema-validation.html#anchor104