### PR TITLE
Fix error description when numbers are interpolated

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -235,7 +235,7 @@ func newError(err ResultError, context *jsonContext, value interface{}, locale l
 // the ErrorDetails struct and vary for each type of error.
 func formatErrorDescription(s string, details ErrorDetails) string {
 	for name, val := range details {
-		s = strings.Replace(s, "%"+strings.ToLower(name)+"%", fmt.Sprintf("%s", val), -1)
+		s = strings.Replace(s, "%"+strings.ToLower(name)+"%", fmt.Sprintf("%v", val), -1)
 	}
 
 	return s


### PR DESCRIPTION
Assuming a JSON schema where an element is defined as:

```json
{
  "type": "array",
  "minItems": 1
}
```

The error message as given by `.Description()` is:

`Array must have at least %!s(int=1) items`

This commit changes it to:

`Array must have at least 1 items`

The same change will apply to any other numeric value interpolation.