### PR TITLE
Fix a bug that cause maximum/minimum validation bad error message, refs #81

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -780,7 +780,7 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 					context,
 					resultErrorFormatJsonNumber(number),
 					ErrorDetails{
-						"min": resultErrorFormatNumber(*currentSubSchema.maximum),
+						"max": resultErrorFormatNumber(*currentSubSchema.maximum),
 					},
 				)
 			}
@@ -791,7 +791,7 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 					context,
 					resultErrorFormatJsonNumber(number),
 					ErrorDetails{
-						"min": resultErrorFormatNumber(*currentSubSchema.maximum),
+						"max": resultErrorFormatNumber(*currentSubSchema.maximum),
 					},
 				)
 			}
@@ -807,7 +807,7 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 					context,
 					resultErrorFormatJsonNumber(number),
 					ErrorDetails{
-						"max": resultErrorFormatNumber(*currentSubSchema.minimum),
+						"min": resultErrorFormatNumber(*currentSubSchema.minimum),
 					},
 				)
 			}
@@ -818,7 +818,7 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 					context,
 					resultErrorFormatJsonNumber(number),
 					ErrorDetails{
-						"max": resultErrorFormatNumber(*currentSubSchema.minimum),
+						"min": resultErrorFormatNumber(*currentSubSchema.minimum),
 					},
 				)
 			}


### PR DESCRIPTION
When we have the following schema:
                "x":{
                    "type":"integer",
                    "minimum": 0
                }
when we need to validate json like x:-1, it will raise the error like `x: Must be greater than %min%"`. 
Maximum also has the same bug.
Issue#81 also logged this bug.