### PR TITLE
Add glide dependency file

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,12 @@
+package: github.com/xeipuuv/gojsonschema
+license: Apache 2.0
+import:
+- package: github.com/xeipuuv/gojsonschema
+
+- package: github.com/xeipuuv/gojsonpointer
+
+- package: github.com/xeipuuv/gojsonreference
+
+- package: github.com/stretchr/testify/assert
+  version: ^1.1.3
+


### PR DESCRIPTION
Adds the `glide.yaml` dependency file, which can be used to install all dependencies into a local `vendor/` folder. See [https://github.com/Masterminds/glide](https://github.com/Masterminds/glide)