### PR TITLE
Fix always-false comparison

### DIFF
--- a/result.go
+++ b/result.go
@@ -126,7 +126,7 @@ func (v ResultErrorFields) String() string {
 	valueString := fmt.Sprintf("%v", v.value)
 
 	// marshal the go value value to json
-	if v.Value == nil {
+	if v.value == nil {
 		valueString = TYPE_NULL
 	} else {
 		if vs, err := marshalToJsonString(v.value); err == nil {


### PR DESCRIPTION
$ go vet
result.go:129: comparison of function Value == nil is always false
exit status 1