### PR TITLE
Fix incorrect string comparison

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -50,10 +50,10 @@ func NewSchema(l JSONLoader) (*Schema, error) {
 	d := Schema{}
 	d.pool = newSchemaPool(l.LoaderFactory())
 	d.documentReference = ref
-	d.referencePool=newSchemaReferencePool()
+	d.referencePool = newSchemaReferencePool()
 
 	var doc interface{}
-	if ref.String() != "#" {
+	if ref.String() != "" {
 		// Get document from schema pool
 		spd, err := d.pool.GetDocument(d.documentReference)
 		if err != nil {

--- a/schema_test.go
+++ b/schema_test.go
@@ -414,3 +414,31 @@ func TestJsonSchemaTestSuite(t *testing.T) {
 
 	fmt.Printf("\n%d tests performed / %d total tests to perform ( %.2f %% )\n", len(JsonSchemaTestSuiteMap), 248, float32(len(JsonSchemaTestSuiteMap))/248.0*100.0)
 }
+
+// From http://json-schema.org/examples.html
+const simpleSchema = `{
+  "title": "Example Schema",
+  "type": "object",
+  "properties": {
+    "firstName": {
+      "type": "string"
+    },
+    "lastName": {
+      "type": "string"
+    },
+    "age": {
+      "description": "Age in years",
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": ["firstName", "lastName"]
+}`
+
+func TestNewStringLoader(t *testing.T) {
+	loader := NewStringLoader(simpleSchema)
+	_, err := NewSchema(loader)
+	if err != nil {
+		t.Errorf("Got error: %s", err.Error())
+	}
+}


### PR DESCRIPTION
The canonical string for these reference is empty and not "#". Also
added a simple test that this functionality works.

Closes #104 