### PR TITLE
Expose ResultErrorFields.String() from ResultError

### DIFF
--- a/result.go
+++ b/result.go
@@ -48,6 +48,7 @@ type (
 		Value() interface{}
 		SetDetails(ErrorDetails)
 		Details() ErrorDetails
+		String() string
 	}
 
 	// ResultErrorFields holds the fields for each ResultError implementation.


### PR DESCRIPTION
I suspect you meant to have this... Looking at the README your examples wouldn't work without...

Ok, to be fair this is random guess, I didn't actually try it... :)
