### PR TITLE
Add String() to ResultError interface

### DIFF
--- a/result.go
+++ b/result.go
@@ -48,6 +48,7 @@ type (
 		Value() interface{}
 		SetDetails(ErrorDetails)
 		Details() ErrorDetails
+		String() string
 	}
 
 	// ResultErrorFields holds the fields for each ResultError implementation.


### PR DESCRIPTION
The method `String()` is not present in the `ResultError` interface so it cannot be used when we get the errors from the `Result` object.
