### PR TITLE
IO loaders

### DIFF
--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -302,6 +302,11 @@ func NewReaderLoader(source io.Reader) (*jsonIOLoader, io.Reader) {
 	return &jsonIOLoader{buf: buf}, io.TeeReader(source, buf)
 }
 
+func NewWriterLoader(source io.Writer) (*jsonIOLoader, io.Writer) {
+	buf := &bytes.Buffer{}
+	return &jsonIOLoader{buf: buf}, io.MultiWriter(source, buf)
+}
+
 func (l *jsonIOLoader) JsonSource() interface{} {
 	return l.buf.String()
 }

--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -293,6 +293,31 @@ func (l *jsonGoLoader) LoadJSON() (interface{}, error) {
 
 }
 
+type jsonIOLoader struct {
+	buf *bytes.Buffer
+}
+
+func NewReaderLoader(source io.Reader) (*jsonIOLoader, io.Reader) {
+	buf := &bytes.Buffer{}
+	return &jsonIOLoader{buf: buf}, io.TeeReader(source, buf)
+}
+
+func (l *jsonIOLoader) JsonSource() interface{} {
+	return l.buf.String()
+}
+
+func (l *jsonIOLoader) LoadJSON() (interface{}, error) {
+	return decodeJsonUsingNumber(l.buf)
+}
+
+func (l *jsonIOLoader) JsonReference() (gojsonreference.JsonReference, error) {
+	return gojsonreference.NewJsonReference("#")
+}
+
+func (l *jsonIOLoader) LoaderFactory() JSONLoaderFactory {
+	return &DefaultJSONLoaderFactory{}
+}
+
 func decodeJsonUsingNumber(r io.Reader) (interface{}, error) {
 
 	var document interface{}

--- a/schema_test.go
+++ b/schema_test.go
@@ -26,7 +26,9 @@
 package gojsonschema
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -491,8 +493,18 @@ const simpleSchema = `{
 }`
 
 func TestLoaders(t *testing.T) {
+	// setup reader loader
+	reader := bytes.NewBufferString(simpleSchema)
+	readerLoader, wrappedReader := NewReaderLoader(reader)
+
+	// drain reader
+	by, err := ioutil.ReadAll(wrappedReader)
+	assert.Nil(t, err)
+	assert.Equal(t, simpleSchema, string(by))
+
 	loaders := []JSONLoader{
 		NewStringLoader(simpleSchema),
+		readerLoader,
 	}
 
 	for _, l := range loaders {
@@ -513,8 +525,18 @@ const invalidPattern = `{
 }`
 
 func TestLoadersWithInvalidPattern(t *testing.T) {
+	// setup reader loader
+	reader := bytes.NewBufferString(invalidPattern)
+	readerLoader, wrappedReader := NewReaderLoader(reader)
+
+	// drain reader
+	by, err := ioutil.ReadAll(wrappedReader)
+	assert.Nil(t, err)
+	assert.Equal(t, invalidPattern, string(by))
+
 	loaders := []JSONLoader{
 		NewStringLoader(invalidPattern),
+		readerLoader,
 	}
 
 	for _, l := range loaders {

--- a/schema_test.go
+++ b/schema_test.go
@@ -28,6 +28,7 @@ package gojsonschema
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -502,9 +503,19 @@ func TestLoaders(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, simpleSchema, string(by))
 
+	// setup writer loaders
+	writer := &bytes.Buffer{}
+	writerLoader, wrappedWriter := NewWriterLoader(writer)
+
+	// fill writer
+	n, err := io.WriteString(wrappedWriter, simpleSchema)
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(simpleSchema))
+
 	loaders := []JSONLoader{
 		NewStringLoader(simpleSchema),
 		readerLoader,
+		writerLoader,
 	}
 
 	for _, l := range loaders {
@@ -534,9 +545,19 @@ func TestLoadersWithInvalidPattern(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, invalidPattern, string(by))
 
+	// setup writer loaders
+	writer := &bytes.Buffer{}
+	writerLoader, wrappedWriter := NewWriterLoader(writer)
+
+	// fill writer
+	n, err := io.WriteString(wrappedWriter, invalidPattern)
+	assert.Nil(t, err)
+	assert.Equal(t, n, len(invalidPattern))
+
 	loaders := []JSONLoader{
 		NewStringLoader(invalidPattern),
 		readerLoader,
+		writerLoader,
 	}
 
 	for _, l := range loaders {

--- a/schema_test.go
+++ b/schema_test.go
@@ -35,6 +35,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const displayErrorMessages = false
@@ -488,11 +490,14 @@ const simpleSchema = `{
   "required": ["firstName", "lastName"]
 }`
 
-func TestNewStringLoader(t *testing.T) {
-	loader := NewStringLoader(simpleSchema)
-	_, err := NewSchema(loader)
-	if err != nil {
-		t.Errorf("Got error: %s", err.Error())
+func TestLoaders(t *testing.T) {
+	loaders := []JSONLoader{
+		NewStringLoader(simpleSchema),
+	}
+
+	for _, l := range loaders {
+		_, err := NewSchema(l)
+		assert.Nil(t, err, "loader: %T", l)
 	}
 }
 
@@ -507,10 +512,13 @@ const invalidPattern = `{
   }
 }`
 
-func TestInvalidPattern(t *testing.T) {
-	loader := NewStringLoader(invalidPattern)
-	_, err := NewSchema(loader)
-	if err == nil {
-		t.Errorf("Expected error for invalid pattern type: %s", err.Error())
+func TestLoadersWithInvalidPattern(t *testing.T) {
+	loaders := []JSONLoader{
+		NewStringLoader(invalidPattern),
+	}
+
+	for _, l := range loaders {
+		_, err := NewSchema(l)
+		assert.NotNil(t, err, "expected error loading invalid pattern: %T", l)
 	}
 }


### PR DESCRIPTION
This adds new loaders for `io.Reader` and `io.Writer` objects.

Validating an http request body:

```go
reqLoader, body := gojsonschema.NewReaderLoader(r.Body)
obj := &someObj{}
err := json.NewDecoder(body).Decode(obj)
r.Body.Close()
assert.Nil(t, err)

res, err := gojsonschema.Validate(schemaLoader, reqLoader)
if assert.Nil(t, err) {
  assert.True(t, res.Valid())
}
```

Validating an http response body:

```go
resLoader, resWriter := gojsonschema.NewWriterLoader(w)
err = json.NewEncoder(resWriter).Encode(someObj)
assert.Nil(t, err)

res, err := gojsonschema.Validate(schemaLoader, reqLoader)
if assert.Nil(t, err) {
  assert.True(t, res.Valid())
}
```

You can see this in use at https://github.com/git-lfs/git-lfs/pull/1931.