### PR TITLE
Fixed custom locale bug#119

### DIFF
--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -175,7 +175,7 @@ func (l *jsonReferenceLoader) loadFromHTTP(address string) (interface{}, error) 
 
 	// must return HTTP Status 200 OK
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(formatErrorDescription(Locale.httpBadStatus(), ErrorDetails{"status": resp.Status}))
+		return nil, errors.New(formatErrorDescription(Locale.HttpBadStatus(), ErrorDetails{"status": resp.Status}))
 	}
 
 	bodyBuff, err := ioutil.ReadAll(resp.Body)

--- a/locales.go
+++ b/locales.go
@@ -73,7 +73,7 @@ type (
 		ReferenceMustBeCanonical() string
 		NotAValidType() string
 		Duplicated() string
-		httpBadStatus() string
+		HttpBadStatus() string
 
 		// ErrorFormat
 		ErrorFormat() string
@@ -256,7 +256,7 @@ func (l DefaultLocale) Duplicated() string {
 	return `{{.type}} type is duplicated`
 }
 
-func (l DefaultLocale) httpBadStatus() string {
+func (l DefaultLocale) HttpBadStatus() string {
 	return `Could not read schema from HTTP, response status is {{.status}}`
 }
 


### PR DESCRIPTION
In locales.go httpBadStatus() is with camel case due to which we cannot use custom local error messages. Fixed this by modifying 'h' to 'H' in both locales.go and jsonLoader.go