### PR TITLE
pass single value out of value map into newError

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -568,7 +568,7 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 							result.addError(
 								new(AdditionalPropertyNotAllowedError),
 								context,
-								value,
+								value[pk],
 								ErrorDetails{"property": pk},
 							)
 						}
@@ -579,7 +579,7 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 							result.addError(
 								new(AdditionalPropertyNotAllowedError),
 								context,
-								value,
+								value[pk],
 								ErrorDetails{"property": pk},
 							)
 						}
@@ -631,7 +631,7 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 				result.addError(
 					new(InvalidPropertyPatternError),
 					context,
-					value,
+					value[pk],
 					ErrorDetails{
 						"property": pk,
 						"pattern":  currentSubSchema.PatternPropertiesString(),


### PR DESCRIPTION
In the validateObject function the "value" variable is a map[string]interface{}. In the loop over the map items not the individual items are passed as value to the addError function, but the whole map is passed. As a result, ResultError.Value() does not return the value but a map with all fields and their values in the map.
This patch fixes that.