### PR TITLE
Strip Fragment from ref URL

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -164,6 +164,8 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 			currentSchema.ref = inheritedReference
 		}
 
+		currentSchema.ref.GetUrl().Fragment = ""
+
 		if sch, ok := d.referencePool.Get(currentSchema.ref.String() + k); ok {
 			currentSchema.refSchema = sch
 


### PR DESCRIPTION
So both in issues https://github.com/xeipuuv/gojsonschema/issues/134 and https://github.com/xeipuuv/gojsonschema/issues/143 something goes wrong in parsing the references. In the code to look up schema references ```currentSchema.ref.String()``` is concatenated with ```k```. It is however possible that both ```currentSchema.ref.String()``` and ```k``` contain a different fragment part, which will lead to invalid references. ```k``` should always contain the fragment part we want to use, so it seems possible to fix the above 2 issues by removing the fragment from the ref url. 

It feels a bit like a hack, but it seems to fix both #134 and #143. I tried more elegant approaches, but I lack thorough knowledge about the code and attempts at nicer solutions didn't work.