### PR TITLE
Error template funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,27 @@ Note in most cases, the err.Details() will be used to generate replacement strin
 {{.field}} must be greater than or equal to {{.min}}
 ```
 
+The library allows you to specify custom template functions, should you require more complex error message handling.
+```go
+gojsonschema.ErrorTemplateFuncs = map[string]interface{}{
+	"allcaps": func(s string) string {
+		return strings.ToUpper(s)
+	},
+}
+```
+
+Given the above definition, you can use the custom function `"allcaps"` in your localization templates:
+```
+{{allcaps .field}} must be greater than or equal to {{.min}}
+```
+
+The above error message would then be rendered with the `field` value in capital letters. For example:
+```
+"PASSWORD must be greater than or equal to 8"
+```
+
+Learn more about what types of template functions you can use in `ErrorTemplateFuncs` by referring to Go's [text/template FuncMap](https://golang.org/pkg/text/template/#FuncMap) type.
+
 ## Formats
 JSON Schema allows for optional "format" property to validate strings against well-known formats. gojsonschema ships with all of the formats defined in the spec that you can use like this:
 ````json

--- a/errors.go
+++ b/errors.go
@@ -257,6 +257,10 @@ func formatErrorDescription(s string, details ErrorDetails) string {
 		errorTemplates.Lock()
 		tpl = errorTemplates.New(s)
 
+		if ErrorTemplateFuncs != nil {
+			tpl.Funcs(ErrorTemplateFuncs)
+		}
+
 		tpl, err = tpl.Parse(s)
 		errorTemplates.Unlock()
 

--- a/schema.go
+++ b/schema.go
@@ -31,6 +31,7 @@ import (
 	"errors"
 	"reflect"
 	"regexp"
+	"text/template"
 
 	"github.com/xeipuuv/gojsonreference"
 )
@@ -39,6 +40,9 @@ var (
 	// Locale is the default locale to use
 	// Library users can overwrite with their own implementation
 	Locale locale = DefaultLocale{}
+
+	// ErrorTemplateFuncs allows you to define custom template funcs for use in localization.
+	ErrorTemplateFuncs template.FuncMap
 )
 
 func NewSchema(l JSONLoader) (*Schema, error) {


### PR DESCRIPTION
I have added the ability to specify a `text/template` `FuncMap` to be applied to the localized error message templates.

My particular use case is that I want to be able to translate JSON field names into something more user friendly.

For example, with this addition, I can change this more technical message

    template.zones.left.modules.2.type is required

into something more suitable for non-technical users:

    The 3rd module in the Left Zone is missing a value for Type.