### PR TITLE
Include Context.String() as parameter for error messages

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -237,6 +237,11 @@ func newError(err ResultError, context *jsonContext, value interface{}, locale l
 	err.SetValue(value)
 	err.SetDetails(details)
 	details["field"] = err.Field()
+
+	if _, exists := details["context"]; !exists && context != nil {
+		details["context"] = context.String()
+	}
+
 	err.SetDescription(formatErrorDescription(d, details))
 }
 


### PR DESCRIPTION
Related to the recently merged #147, this adds the context string information (e.g. `"(root).template.zones.sidebar.modules.0"`) as a property available inside the error message formatting templates.