### PR TITLE
ignore any format's that aren't defined

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -586,11 +586,6 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 		formatString, ok := m[KEY_FORMAT].(string)
 		if ok && FormatCheckers.Has(formatString) {
 			currentSchema.format = formatString
-		} else {
-			return errors.New(formatErrorDescription(
-				Locale.MustBeValidFormat(),
-				ErrorDetails{"key": KEY_FORMAT, "given": m[KEY_FORMAT]},
-			))
 		}
 	}
 


### PR DESCRIPTION
- reference: https://spacetelescope.github.io/understanding-json-schema/reference/string.html#format