### PR TITLE
Allow "#/path" pointers on Loader sources

### DIFF
--- a/json_schema_test_suite/ref/schema_6.json
+++ b/json_schema_test_suite/ref/schema_6.json
@@ -1,0 +1,1 @@
+{"type":"object","additionalProperties":false,"definitions":{"x":{"type":"integer"}}}

--- a/schema.go
+++ b/schema.go
@@ -64,6 +64,13 @@ func NewSchema(l JSONLoader) (*Schema, error) {
 			return nil, err
 		}
 		doc = spd.Document
+
+		// Deal with fragment pointers
+		jsonPointer := ref.GetPointer()
+		doc, _, err = jsonPointer.Get(doc)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// Load JSON directly
 		doc, err = l.LoadJSON()

--- a/schema_test.go
+++ b/schema_test.go
@@ -254,6 +254,8 @@ func TestJsonSchemaTestSuite(t *testing.T) {
 		{"phase": "root pointer ref", "test": "recursive match", "schema": "ref/schema_0.json", "data": "ref/data_01.json", "valid": "true"},
 		{"phase": "root pointer ref", "test": "mismatch", "schema": "ref/schema_0.json", "data": "ref/data_02.json", "valid": "false", "errors": "additional_property_not_allowed"},
 		{"phase": "root pointer ref", "test": "recursive mismatch", "schema": "ref/schema_0.json", "data": "ref/data_03.json", "valid": "false", "errors": "additional_property_not_allowed"},
+		{"phase": "loader pointer ref", "test": "root ref valid", "schema": "ref/schema_6.json#/definitions/x", "data": "ref/data_40.json", "valid": "true"},
+		{"phase": "loader pointer ref", "test": "root ref invalid", "schema": "ref/schema_6.json#/definitions/x", "data": "ref/data_41.json", "valid": "false", "errors": "invalid_type"},
 		{"phase": "relative pointer ref to object", "test": "match", "schema": "ref/schema_1.json", "data": "ref/data_10.json", "valid": "true"},
 		{"phase": "relative pointer ref to object", "test": "mismatch", "schema": "ref/schema_1.json", "data": "ref/data_11.json", "valid": "false", "errors": "invalid_type"},
 		{"phase": "relative pointer ref to array", "test": "match array", "schema": "ref/schema_2.json", "data": "ref/data_20.json", "valid": "true"},


### PR DESCRIPTION
Allow "#/path" pointers on Loader sources

If the URL passed to NewReferenceLoader contains a #/path fragment it is currently ignored and the "root" schema is used instead.

This change makes it possible to validate against a sub-schema in a file directly -- without this change I had to create a temp schema that just contained a "$ref": i.e.:

```golang
subSchema := "file://…/schemas/common.json#/definitions/file-info"
sl := NewReferenceLoader(subSchema)
Validate(sl, NewGoLoader(myObj)
```

