### PR TITLE
Implement id parsing in conjuction with $ref fixes

### DIFF
--- a/schemaPool.go
+++ b/schemaPool.go
@@ -62,11 +62,15 @@ func (p *schemaPool) GetStandaloneDocument() (document interface{}) {
 
 func (p *schemaPool) GetDocument(reference gojsonreference.JsonReference) (*schemaPoolDocument, error) {
 
+	var (
+		spd *schemaPoolDocument
+		ok  bool
+		err error
+	)
+
 	if internalLogEnabled {
 		internalLog("Get Document ( %s )", reference.String())
 	}
-
-	var err error
 
 	// It is not possible to load anything that is not canonical...
 	if !reference.IsCanonical() {
@@ -75,20 +79,10 @@ func (p *schemaPool) GetDocument(reference gojsonreference.JsonReference) (*sche
 			ErrorDetails{"reference": reference},
 		))
 	}
-
 	refToUrl := reference
 	refToUrl.GetUrl().Fragment = ""
 
-	var spd *schemaPoolDocument
-
-	// Try to find the requested document in the pool
-	for k := range p.schemaPoolDocuments {
-		if k == refToUrl.String() {
-			spd = p.schemaPoolDocuments[k]
-		}
-	}
-
-	if spd != nil {
+	if spd, ok = p.schemaPoolDocuments[refToUrl.String()]; ok {
 		if internalLogEnabled {
 			internalLog(" From pool")
 		}

--- a/schemaReferencePool.go
+++ b/schemaReferencePool.go
@@ -62,6 +62,7 @@ func (p *schemaReferencePool) Add(ref string, sch *subSchema) {
 	if internalLogEnabled {
 		internalLog(fmt.Sprintf("Add Schema Reference %s to pool", ref))
 	}
-
-	p.documents[ref] = sch
+	if _, ok := p.documents[ref]; !ok {
+		p.documents[ref] = sch
+	}
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -360,11 +360,9 @@ func TestJsonSchemaTestSuite(t *testing.T) {
 		{"phase": "format validation", "test": "uri format is invalid", "schema": "format/schema_6.json", "data": "format/data_13.json", "valid": "false", "errors": "format"},
 		{"phase": "format validation", "test": "number format is valid", "schema": "format/schema_7.json", "data": "format/data_29.json", "valid": "true"},
 		{"phase": "format validation", "test": "number format is valid", "schema": "format/schema_7.json", "data": "format/data_30.json", "valid": "false", "errors": "format"},
+		{"phase": "change resolution scope", "test": "changed scope ref valid", "schema": "refRemote/schema_3.json", "data": "refRemote/data_30.json", "valid": "true"},
+		{"phase": "change resolution scope", "test": "changed scope ref invalid", "schema": "refRemote/schema_3.json", "data": "refRemote/data_31.json", "valid": "false", "errors": "invalid_type"},
 	}
-
-	//TODO Pass failed tests : id(s) as scope for references is not implemented yet
-	//map[string]string{"phase": "change resolution scope", "test": "changed scope ref valid", "schema": "refRemote/schema_3.json", "data": "refRemote/data_30.json", "valid": "true"},
-	//map[string]string{"phase": "change resolution scope", "test": "changed scope ref invalid", "schema": "refRemote/schema_3.json", "data": "refRemote/data_31.json", "valid": "false"}}
 
 	// Setup a small http server on localhost:1234 for testing purposes
 
@@ -416,6 +414,9 @@ func TestJsonSchemaTestSuite(t *testing.T) {
 		expectedValid, _ := strconv.ParseBool(testJson["valid"])
 		if givenValid != expectedValid {
 			t.Errorf("Test failed : %s :: %s, expects %t, given %t\n", testJson["phase"], testJson["test"], expectedValid, givenValid)
+			for _, e := range result.Errors() {
+				fmt.Println("Error: " + e.Type())
+			}
 		}
 
 		if !givenValid && testJson["errors"] != "" {

--- a/subSchema.go
+++ b/subSchema.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	KEY_SCHEMA                = "$subSchema"
-	KEY_ID                    = "$id"
+	KEY_ID                    = "id"
 	KEY_REF                   = "$ref"
 	KEY_TITLE                 = "title"
 	KEY_DESCRIPTION           = "description"
@@ -73,7 +73,7 @@ const (
 type subSchema struct {
 
 	// basic subSchema meta properties
-	id          *string
+	id          *gojsonreference.JsonReference
 	title       *string
 	description *string
 


### PR DESCRIPTION
This commit adds support for the `id` keyword and rewrites part of the code that deals with schema references. In conjuction with https://github.com/xeipuuv/gojsonreference/pull/8 this fixes issues #134, #143, #168, #170, which were all related to schema references in one way or another.