### PR TITLE
Move stretchr/testify to an explicit test dep with corrected version

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -9,6 +9,5 @@ import:
 
 testImport:
 - package: github.com/stretchr/testify
-  version: ^v1.1.3
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,6 +7,8 @@ import:
 
 - package: github.com/xeipuuv/gojsonreference
 
-- package: github.com/stretchr/testify/assert
-  version: ^1.1.3
-
+testImport:
+- package: github.com/stretchr/testify
+  version: ^v1.1.3
+  subpackages:
+  - assert


### PR DESCRIPTION
This moves stretchr/testify to an explicit test dependency with a corrected tag.

It does not attempt to update the version of stretchr/testify used; it is simply to work around the issue documented in #175 