### PR TITLE
Add a new option for schemas, a reference resolver

### DIFF
--- a/json_schema_test_suite/refResolver/schema.json
+++ b/json_schema_test_suite/refResolver/schema.json
@@ -1,0 +1,4 @@
+{
+    "id": "http://example.com/schema.json",
+    "$ref": "subschema.json#!/"
+}

--- a/json_schema_test_suite/refResolver/subschema.json
+++ b/json_schema_test_suite/refResolver/subschema.json
@@ -1,0 +1,9 @@
+{
+    "id": "http://example.com/subschema.json",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
This allows you to define a reference resolver func that will be called to
resolve references that don't have complete URLs, like "foo.json#/".

An example of where this is useful is if you'd like to resolve these to a
local filesystem instead of using the schema's ID value as a base URL for
resolution.

The new parameters to NewSchema are received as varargs in order to not break
existing code that is calling NewSchema with just 1 parameter. The new
parameters are a struct so that _other_ new parameters can be added in the
future without API breakage.