### PR TITLE
Fixed bug with loading json files using windows filepaths 

### DIFF
--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -126,7 +126,14 @@ func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
 
 	var err error
 
-	reference, err := gojsonreference.NewJsonReference(l.JsonSource().(string))
+	url := l.JsonSource().(string)
+	if runtime.GOOS == "windows" {
+		// On Windows, passed canonical paths will have backslashes which will
+		// cause an error during the NewJsonReference call.
+		// Replace the backslashes with forwardslash to not get that error.
+		url = filepath.ToSlash(url)
+	}
+	reference, err := gojsonreference.NewJsonReference(url)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +149,7 @@ func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
 		if runtime.GOOS == "windows" {
 			// on Windows, a file URL may have an extra leading slash, use slashes
 			// instead of backslashes, and have spaces escaped
-			if strings.HasPrefix(filename, "/") {
+			if strings.HasPrefix(filename, "//") {
 				filename = filename[1:]
 			}
 			filename = filepath.FromSlash(filename)


### PR DESCRIPTION
jsonReferenceLoader#LoadJson fails when loading files in a window's file system.

To reproduce, on a windows machine, use this example from [my Github](https://github.com/Daniel-Houston/examples):

file.json
```
{
	"id":"1",
	"description": "A Description"
}
```

main.go
```
package main

import (
	"fmt"
	"log"
	"path/filepath"

	"github.com/xeipuuv/gojsonschema"
)

const schema = `
{
	"type":"object",
	"properties":{
		"id":{
			"type":"string"
		},
		"description":{
			"type":"string"
		}
	}
}
`

func main() {
	file := "file.json"
	canonical, err := filepath.Abs(file)
	if err != nil {
		log.Fatal(err)
	}

	schemaLoader := gojsonschema.NewStringLoader(schema)
	documentLoader := gojsonschema.NewReferenceLoader("file://" + canonical)

	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
	if err != nil {
		log.Fatal(err)
	}

	if result.Valid() {
		fmt.Printf("The document is valid\n")
	} else {
		fmt.Printf("The document is not valid. see errors :\n")
		for _, desc := range result.Errors() {
			fmt.Printf("- %s\n", desc)
		}
	}
}

```

```
$ go run main.go
2018/05/16 11:09:34 parse file://C:\Users\danielhouston\go\src\github.com\Daniel-Houston\examples\file.json: invalid character "\\" in host name
exit status 1
```

The example works fine on Linux, but fails on Windows. 

Please let me know if there is anything else you would like from me before you merge it, as I would like to get this fix in ASAP.

Thanks!