### PR TITLE
Use the entire file URI, rather than just the path when reading files from the filesystem

### DIFF
--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -138,13 +138,11 @@ func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
 
 	if reference.HasFileScheme {
 
-		filename := strings.Replace(refToUrl.GetUrl().Path, "file://", "", -1)
+		filename := strings.TrimPrefix(refToUrl.String(), "file://")
 		if runtime.GOOS == "windows" {
 			// on Windows, a file URL may have an extra leading slash, use slashes
 			// instead of backslashes, and have spaces escaped
-			if strings.HasPrefix(filename, "/") {
-				filename = filename[1:]
-			}
+			filename = strings.TrimPrefix(filename, "/")
 			filename = filepath.FromSlash(filename)
 		}
 


### PR DESCRIPTION
Drive letters on Windows are part of the hostname in an URI, so the entire URI must be used. This closes issue #209 