### PR TITLE
Fixing issue of "required" error description not aligning with README or comments

### DIFF
--- a/result.go
+++ b/result.go
@@ -76,12 +76,6 @@ type (
 // Field outputs the field name without the root context
 // i.e. firstName or person.firstName instead of (root).firstName or (root).person.firstName
 func (v *ResultErrorFields) Field() string {
-	if p, ok := v.Details()["property"]; ok {
-		if str, isString := p.(string); isString {
-			return str
-		}
-	}
-
 	return strings.TrimPrefix(v.context.String(), STRING_ROOT_SCHEMA_PROPERTY+".")
 }
 


### PR DESCRIPTION
I'm experiencing an issue with required error message not returning the most useful error message especially if I require 2 fields with the same name under different levels

An [issue](https://github.com/xeipuuv/gojsonschema/issues/187) regarding this is also available so I'm thinking about removing the if statement in `result.go` to fix the issue unless removing it will cause more issues.

Using the simple JSON below as example to explain why this is undesirable,

```
{
	"people": {
		"properties": {
			"owner": {
				"properties": {
					"name": "string"
				},
				"required": [
					"name"
				]
			}
		}
	}

	...

	"pet": {
		"properties": {
			"dog": {
				"properties": {
					"name": "string"
				},
				"required": [
					"name"
				]
			}
		}
	}
}
```

Assuming the name field for owner is missing, the error would be: 
	`name: name is required`
instead of 
	`people.owner: name is required`

This makes it very difficult to know where the name is required and creates confusion as in the README and comments in `result.go`, it suggested that only the `(root).` portion will be trimmed