### PR TITLE
Differentiate between different drafts and metaschema validation

### DIFF
--- a/draft.go
+++ b/draft.go
@@ -1,0 +1,23 @@
+package gojsonschema
+
+type Draft int
+
+const (
+	Hybrid Draft = 0
+	Draft4 Draft = 4
+	Draft6 Draft = 6
+	Draft7 Draft = 7
+)
+
+var (
+	draftDict = map[Draft]string{
+		Draft4: "http://json-schema.org/draft-04/schema",
+		Draft6: "http://json-schema.org/draft-06/schema",
+		Draft7: "http://json-schema.org/draft-07/schema",
+	}
+	schemaDict = map[string]Draft{
+		"http://json-schema.org/draft-04/schema": Draft4,
+		"http://json-schema.org/draft-06/schema": Draft6,
+		"http://json-schema.org/draft-07/schema": Draft7,
+	}
+)

--- a/draft.go
+++ b/draft.go
@@ -1,7 +1,22 @@
+// Copyright 2018 johandorland ( https://github.com/johandorland )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gojsonschema
 
 import (
 	"errors"
+	"math"
 	"reflect"
 
 	"github.com/xeipuuv/gojsonreference"
@@ -10,10 +25,10 @@ import (
 type Draft int
 
 const (
-	Hybrid Draft = 0
 	Draft4 Draft = 4
 	Draft6 Draft = 6
 	Draft7 Draft = 7
+	Hybrid Draft = math.MaxInt32
 )
 
 type draftConfig struct {

--- a/draft.go
+++ b/draft.go
@@ -1,5 +1,12 @@
 package gojsonschema
 
+import (
+	"errors"
+	"reflect"
+
+	"github.com/xeipuuv/gojsonreference"
+)
+
 type Draft int
 
 const (
@@ -9,15 +16,101 @@ const (
 	Draft7 Draft = 7
 )
 
-var (
-	draftDict = map[Draft]string{
-		Draft4: "http://json-schema.org/draft-04/schema",
-		Draft6: "http://json-schema.org/draft-06/schema",
-		Draft7: "http://json-schema.org/draft-07/schema",
+type draftConfig struct {
+	Version       Draft
+	MetaSchemaURL string
+	MetaSchema    string
+}
+type draftConfigs []draftConfig
+
+var drafts draftConfigs
+
+func init() {
+	drafts = []draftConfig{
+		draftConfig{
+			Version:       Draft4,
+			MetaSchemaURL: "http://json-schema.org/draft-04/schema",
+			MetaSchema:    `{"id":"http://json-schema.org/draft-04/schema#","$schema":"http://json-schema.org/draft-04/schema#","description":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"positiveInteger":{"type":"integer","minimum":0},"positiveIntegerDefault0":{"allOf":[{"$ref":"#/definitions/positiveInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"minItems":1,"uniqueItems":true}},"type":"object","properties":{"id":{"type":"string"},"$schema":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"},"default":{},"multipleOf":{"type":"number","minimum":0,"exclusiveMinimum":true},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"boolean","default":false},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"boolean","default":false},"maxLength":{"$ref":"#/definitions/positiveInteger"},"minLength":{"$ref":"#/definitions/positiveIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"anyOf":[{"type":"boolean"},{"$ref":"#"}],"default":{}},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":{}},"maxItems":{"$ref":"#/definitions/positiveInteger"},"minItems":{"$ref":"#/definitions/positiveIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"maxProperties":{"$ref":"#/definitions/positiveInteger"},"minProperties":{"$ref":"#/definitions/positiveIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"anyOf":[{"type":"boolean"},{"$ref":"#"}],"default":{}},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"enum":{"type":"array","minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"dependencies":{"exclusiveMaximum":["maximum"],"exclusiveMinimum":["minimum"]},"default":{}}`,
+		},
+		draftConfig{
+			Version:       Draft6,
+			MetaSchemaURL: "http://json-schema.org/draft-06/schema",
+			MetaSchema:    `{"$schema":"http://json-schema.org/draft-06/schema#","$id":"http://json-schema.org/draft-06/schema#","title":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"nonNegativeInteger":{"type":"integer","minimum":0},"nonNegativeIntegerDefault0":{"allOf":[{"$ref":"#/definitions/nonNegativeInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"uniqueItems":true,"default":[]}},"type":["object","boolean"],"properties":{"$id":{"type":"string","format":"uri-reference"},"$schema":{"type":"string","format":"uri"},"$ref":{"type":"string","format":"uri-reference"},"title":{"type":"string"},"description":{"type":"string"},"default":{},"examples":{"type":"array","items":{}},"multipleOf":{"type":"number","exclusiveMinimum":0},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"number"},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"number"},"maxLength":{"$ref":"#/definitions/nonNegativeInteger"},"minLength":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"$ref":"#"},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":{}},"maxItems":{"$ref":"#/definitions/nonNegativeInteger"},"minItems":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"contains":{"$ref":"#"},"maxProperties":{"$ref":"#/definitions/nonNegativeInteger"},"minProperties":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"$ref":"#"},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"propertyNames":{"$ref":"#"},"const":{},"enum":{"type":"array","minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"default":{}}`,
+		},
+		draftConfig{
+			Version:       Draft7,
+			MetaSchemaURL: "http://json-schema.org/draft-07/schema",
+			MetaSchema:    `{"$schema":"http://json-schema.org/draft-07/schema#","$id":"http://json-schema.org/draft-07/schema#","title":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"nonNegativeInteger":{"type":"integer","minimum":0},"nonNegativeIntegerDefault0":{"allOf":[{"$ref":"#/definitions/nonNegativeInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"uniqueItems":true,"default":[]}},"type":["object","boolean"],"properties":{"$id":{"type":"string","format":"uri-reference"},"$schema":{"type":"string","format":"uri"},"$ref":{"type":"string","format":"uri-reference"},"$comment":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"},"default":true,"readOnly":{"type":"boolean","default":false},"examples":{"type":"array","items":true},"multipleOf":{"type":"number","exclusiveMinimum":0},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"number"},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"number"},"maxLength":{"$ref":"#/definitions/nonNegativeInteger"},"minLength":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"$ref":"#"},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":true},"maxItems":{"$ref":"#/definitions/nonNegativeInteger"},"minItems":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"contains":{"$ref":"#"},"maxProperties":{"$ref":"#/definitions/nonNegativeInteger"},"minProperties":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"$ref":"#"},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"propertyNames":{"format":"regex"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"propertyNames":{"$ref":"#"},"const":true,"enum":{"type":"array","items":true,"minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"contentMediaType":{"type":"string"},"contentEncoding":{"type":"string"},"if":{"$ref":"#"},"then":{"$ref":"#"},"else":{"$ref":"#"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"default":true}`,
+		},
 	}
-	schemaDict = map[string]Draft{
-		"http://json-schema.org/draft-04/schema": Draft4,
-		"http://json-schema.org/draft-06/schema": Draft6,
-		"http://json-schema.org/draft-07/schema": Draft7,
+}
+
+func (dc draftConfigs) GetMetaSchema(url string) string {
+	for _, config := range dc {
+		if config.MetaSchemaURL == url {
+			return config.MetaSchema
+		}
 	}
-)
+	return ""
+}
+func (dc draftConfigs) GetDraftVersion(url string) *Draft {
+	for _, config := range dc {
+		if config.MetaSchemaURL == url {
+			return &config.Version
+		}
+	}
+	return nil
+}
+func (dc draftConfigs) GetSchemaURL(draft Draft) string {
+	for _, config := range dc {
+		if config.Version == draft {
+			return config.MetaSchemaURL
+		}
+	}
+	return ""
+}
+
+func parseSchemaURL(documentNode interface{}) (string, *Draft, error) {
+
+	if isKind(documentNode, reflect.Bool) {
+		return "", nil, nil
+	}
+	m := documentNode.(map[string]interface{})
+
+	if existsMapKey(m, KEY_SCHEMA) {
+		if !isKind(m[KEY_SCHEMA], reflect.String) {
+			return "", nil, errors.New(formatErrorDescription(
+				Locale.MustBeOfType(),
+				ErrorDetails{
+					"key":  KEY_SCHEMA,
+					"type": TYPE_STRING,
+				},
+			))
+		}
+
+		schemaReference, err := gojsonreference.NewJsonReference(m[KEY_SCHEMA].(string))
+
+		if err != nil {
+			return "", nil, err
+		}
+
+		schema := schemaReference.String()
+
+		return schema, drafts.GetDraftVersion(schema), nil
+	}
+
+	return "", nil, nil
+}
+
+// var (
+// 	draftDict = map[Draft]string{
+// 		Draft4: "http://json-schema.org/draft-04/schema",
+// 		Draft6: "http://json-schema.org/draft-06/schema",
+// 		Draft7: "http://json-schema.org/draft-07/schema",
+// 	}
+// 	schemaDict = map[string]Draft{
+// 		"http://json-schema.org/draft-04/schema": Draft4,
+// 		"http://json-schema.org/draft-06/schema": Draft6,
+// 		"http://json-schema.org/draft-07/schema": Draft7,
+// 	}
+// )

--- a/draft.go
+++ b/draft.go
@@ -101,16 +101,3 @@ func parseSchemaURL(documentNode interface{}) (string, *Draft, error) {
 
 	return "", nil, nil
 }
-
-// var (
-// 	draftDict = map[Draft]string{
-// 		Draft4: "http://json-schema.org/draft-04/schema",
-// 		Draft6: "http://json-schema.org/draft-06/schema",
-// 		Draft7: "http://json-schema.org/draft-07/schema",
-// 	}
-// 	schemaDict = map[string]Draft{
-// 		"http://json-schema.org/draft-04/schema": Draft4,
-// 		"http://json-schema.org/draft-06/schema": Draft6,
-// 		"http://json-schema.org/draft-07/schema": Draft7,
-// 	}
-// )

--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -166,32 +166,28 @@ func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
 
 func (l *jsonReferenceLoader) loadFromHTTP(address string) (interface{}, error) {
 
-	switch address {
-	case "http://json-schema.org/draft-04/schema":
-		return decodeJsonUsingNumber(strings.NewReader(`{"id":"http://json-schema.org/draft-04/schema#","$schema":"http://json-schema.org/draft-04/schema#","description":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"positiveInteger":{"type":"integer","minimum":0},"positiveIntegerDefault0":{"allOf":[{"$ref":"#/definitions/positiveInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"minItems":1,"uniqueItems":true}},"type":"object","properties":{"id":{"type":"string"},"$schema":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"},"default":{},"multipleOf":{"type":"number","minimum":0,"exclusiveMinimum":true},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"boolean","default":false},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"boolean","default":false},"maxLength":{"$ref":"#/definitions/positiveInteger"},"minLength":{"$ref":"#/definitions/positiveIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"anyOf":[{"type":"boolean"},{"$ref":"#"}],"default":{}},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":{}},"maxItems":{"$ref":"#/definitions/positiveInteger"},"minItems":{"$ref":"#/definitions/positiveIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"maxProperties":{"$ref":"#/definitions/positiveInteger"},"minProperties":{"$ref":"#/definitions/positiveIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"anyOf":[{"type":"boolean"},{"$ref":"#"}],"default":{}},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"enum":{"type":"array","minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"dependencies":{"exclusiveMaximum":["maximum"],"exclusiveMinimum":["minimum"]},"default":{}}`))
-	case "http://json-schema.org/draft-06/schema":
-		return decodeJsonUsingNumber(strings.NewReader(`{"$schema":"http://json-schema.org/draft-06/schema#","$id":"http://json-schema.org/draft-06/schema#","title":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"nonNegativeInteger":{"type":"integer","minimum":0},"nonNegativeIntegerDefault0":{"allOf":[{"$ref":"#/definitions/nonNegativeInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"uniqueItems":true,"default":[]}},"type":["object","boolean"],"properties":{"$id":{"type":"string","format":"uri-reference"},"$schema":{"type":"string","format":"uri"},"$ref":{"type":"string","format":"uri-reference"},"title":{"type":"string"},"description":{"type":"string"},"default":{},"examples":{"type":"array","items":{}},"multipleOf":{"type":"number","exclusiveMinimum":0},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"number"},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"number"},"maxLength":{"$ref":"#/definitions/nonNegativeInteger"},"minLength":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"$ref":"#"},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":{}},"maxItems":{"$ref":"#/definitions/nonNegativeInteger"},"minItems":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"contains":{"$ref":"#"},"maxProperties":{"$ref":"#/definitions/nonNegativeInteger"},"minProperties":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"$ref":"#"},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"propertyNames":{"$ref":"#"},"const":{},"enum":{"type":"array","minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"default":{}}`))
-	case "http://json-schema.org/draft-07/schema":
-		return decodeJsonUsingNumber(strings.NewReader(`{"$schema":"http://json-schema.org/draft-07/schema#","$id":"http://json-schema.org/draft-07/schema#","title":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"nonNegativeInteger":{"type":"integer","minimum":0},"nonNegativeIntegerDefault0":{"allOf":[{"$ref":"#/definitions/nonNegativeInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"uniqueItems":true,"default":[]}},"type":["object","boolean"],"properties":{"$id":{"type":"string","format":"uri-reference"},"$schema":{"type":"string","format":"uri"},"$ref":{"type":"string","format":"uri-reference"},"$comment":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"},"default":true,"readOnly":{"type":"boolean","default":false},"examples":{"type":"array","items":true},"multipleOf":{"type":"number","exclusiveMinimum":0},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"number"},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"number"},"maxLength":{"$ref":"#/definitions/nonNegativeInteger"},"minLength":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"$ref":"#"},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":true},"maxItems":{"$ref":"#/definitions/nonNegativeInteger"},"minItems":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"contains":{"$ref":"#"},"maxProperties":{"$ref":"#/definitions/nonNegativeInteger"},"minProperties":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"$ref":"#"},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"propertyNames":{"format":"regex"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"propertyNames":{"$ref":"#"},"const":true,"enum":{"type":"array","items":true,"minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"contentMediaType":{"type":"string"},"contentEncoding":{"type":"string"},"if":{"$ref":"#"},"then":{"$ref":"#"},"else":{"$ref":"#"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"default":true}`))
-	default:
-
-		resp, err := http.Get(address)
-		if err != nil {
-			return nil, err
-		}
-
-		// must return HTTP Status 200 OK
-		if resp.StatusCode != http.StatusOK {
-			return nil, errors.New(formatErrorDescription(Locale.HttpBadStatus(), ErrorDetails{"status": resp.Status}))
-		}
-
-		bodyBuff, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		return decodeJsonUsingNumber(bytes.NewReader(bodyBuff))
+	// returned cached versions for metaschemas for drafts 4, 6 and 7
+	// for performance and allow for easier offline use
+	if metaSchema := drafts.GetMetaSchema(address); metaSchema != "" {
+		return decodeJsonUsingNumber(strings.NewReader(metaSchema))
 	}
+
+	resp, err := http.Get(address)
+	if err != nil {
+		return nil, err
+	}
+
+	// must return HTTP Status 200 OK
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(formatErrorDescription(Locale.HttpBadStatus(), ErrorDetails{"status": resp.Status}))
+	}
+
+	bodyBuff, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodeJsonUsingNumber(bytes.NewReader(bodyBuff))
 }
 
 func (l *jsonReferenceLoader) loadFromFile(path string) (interface{}, error) {

--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -166,23 +166,32 @@ func (l *jsonReferenceLoader) LoadJSON() (interface{}, error) {
 
 func (l *jsonReferenceLoader) loadFromHTTP(address string) (interface{}, error) {
 
-	resp, err := http.Get(address)
-	if err != nil {
-		return nil, err
+	switch address {
+	case "http://json-schema.org/draft-04/schema":
+		return decodeJsonUsingNumber(strings.NewReader(`{"id":"http://json-schema.org/draft-04/schema#","$schema":"http://json-schema.org/draft-04/schema#","description":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"positiveInteger":{"type":"integer","minimum":0},"positiveIntegerDefault0":{"allOf":[{"$ref":"#/definitions/positiveInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"minItems":1,"uniqueItems":true}},"type":"object","properties":{"id":{"type":"string"},"$schema":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"},"default":{},"multipleOf":{"type":"number","minimum":0,"exclusiveMinimum":true},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"boolean","default":false},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"boolean","default":false},"maxLength":{"$ref":"#/definitions/positiveInteger"},"minLength":{"$ref":"#/definitions/positiveIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"anyOf":[{"type":"boolean"},{"$ref":"#"}],"default":{}},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":{}},"maxItems":{"$ref":"#/definitions/positiveInteger"},"minItems":{"$ref":"#/definitions/positiveIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"maxProperties":{"$ref":"#/definitions/positiveInteger"},"minProperties":{"$ref":"#/definitions/positiveIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"anyOf":[{"type":"boolean"},{"$ref":"#"}],"default":{}},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"enum":{"type":"array","minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"dependencies":{"exclusiveMaximum":["maximum"],"exclusiveMinimum":["minimum"]},"default":{}}`))
+	case "http://json-schema.org/draft-06/schema":
+		return decodeJsonUsingNumber(strings.NewReader(`{"$schema":"http://json-schema.org/draft-06/schema#","$id":"http://json-schema.org/draft-06/schema#","title":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"nonNegativeInteger":{"type":"integer","minimum":0},"nonNegativeIntegerDefault0":{"allOf":[{"$ref":"#/definitions/nonNegativeInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"uniqueItems":true,"default":[]}},"type":["object","boolean"],"properties":{"$id":{"type":"string","format":"uri-reference"},"$schema":{"type":"string","format":"uri"},"$ref":{"type":"string","format":"uri-reference"},"title":{"type":"string"},"description":{"type":"string"},"default":{},"examples":{"type":"array","items":{}},"multipleOf":{"type":"number","exclusiveMinimum":0},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"number"},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"number"},"maxLength":{"$ref":"#/definitions/nonNegativeInteger"},"minLength":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"$ref":"#"},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":{}},"maxItems":{"$ref":"#/definitions/nonNegativeInteger"},"minItems":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"contains":{"$ref":"#"},"maxProperties":{"$ref":"#/definitions/nonNegativeInteger"},"minProperties":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"$ref":"#"},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"propertyNames":{"$ref":"#"},"const":{},"enum":{"type":"array","minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"default":{}}`))
+	case "http://json-schema.org/draft-07/schema":
+		return decodeJsonUsingNumber(strings.NewReader(`{"$schema":"http://json-schema.org/draft-07/schema#","$id":"http://json-schema.org/draft-07/schema#","title":"Core schema meta-schema","definitions":{"schemaArray":{"type":"array","minItems":1,"items":{"$ref":"#"}},"nonNegativeInteger":{"type":"integer","minimum":0},"nonNegativeIntegerDefault0":{"allOf":[{"$ref":"#/definitions/nonNegativeInteger"},{"default":0}]},"simpleTypes":{"enum":["array","boolean","integer","null","number","object","string"]},"stringArray":{"type":"array","items":{"type":"string"},"uniqueItems":true,"default":[]}},"type":["object","boolean"],"properties":{"$id":{"type":"string","format":"uri-reference"},"$schema":{"type":"string","format":"uri"},"$ref":{"type":"string","format":"uri-reference"},"$comment":{"type":"string"},"title":{"type":"string"},"description":{"type":"string"},"default":true,"readOnly":{"type":"boolean","default":false},"examples":{"type":"array","items":true},"multipleOf":{"type":"number","exclusiveMinimum":0},"maximum":{"type":"number"},"exclusiveMaximum":{"type":"number"},"minimum":{"type":"number"},"exclusiveMinimum":{"type":"number"},"maxLength":{"$ref":"#/definitions/nonNegativeInteger"},"minLength":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"pattern":{"type":"string","format":"regex"},"additionalItems":{"$ref":"#"},"items":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/schemaArray"}],"default":true},"maxItems":{"$ref":"#/definitions/nonNegativeInteger"},"minItems":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"uniqueItems":{"type":"boolean","default":false},"contains":{"$ref":"#"},"maxProperties":{"$ref":"#/definitions/nonNegativeInteger"},"minProperties":{"$ref":"#/definitions/nonNegativeIntegerDefault0"},"required":{"$ref":"#/definitions/stringArray"},"additionalProperties":{"$ref":"#"},"definitions":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"properties":{"type":"object","additionalProperties":{"$ref":"#"},"default":{}},"patternProperties":{"type":"object","additionalProperties":{"$ref":"#"},"propertyNames":{"format":"regex"},"default":{}},"dependencies":{"type":"object","additionalProperties":{"anyOf":[{"$ref":"#"},{"$ref":"#/definitions/stringArray"}]}},"propertyNames":{"$ref":"#"},"const":true,"enum":{"type":"array","items":true,"minItems":1,"uniqueItems":true},"type":{"anyOf":[{"$ref":"#/definitions/simpleTypes"},{"type":"array","items":{"$ref":"#/definitions/simpleTypes"},"minItems":1,"uniqueItems":true}]},"format":{"type":"string"},"contentMediaType":{"type":"string"},"contentEncoding":{"type":"string"},"if":{"$ref":"#"},"then":{"$ref":"#"},"else":{"$ref":"#"},"allOf":{"$ref":"#/definitions/schemaArray"},"anyOf":{"$ref":"#/definitions/schemaArray"},"oneOf":{"$ref":"#/definitions/schemaArray"},"not":{"$ref":"#"}},"default":true}`))
+	default:
+
+		resp, err := http.Get(address)
+		if err != nil {
+			return nil, err
+		}
+
+		// must return HTTP Status 200 OK
+		if resp.StatusCode != http.StatusOK {
+			return nil, errors.New(formatErrorDescription(Locale.HttpBadStatus(), ErrorDetails{"status": resp.Status}))
+		}
+
+		bodyBuff, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		return decodeJsonUsingNumber(bytes.NewReader(bodyBuff))
 	}
-
-	// must return HTTP Status 200 OK
-	if resp.StatusCode != http.StatusOK {
-		return nil, errors.New(formatErrorDescription(Locale.HttpBadStatus(), ErrorDetails{"status": resp.Status}))
-	}
-
-	bodyBuff, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	return decodeJsonUsingNumber(bytes.NewReader(bodyBuff))
-
 }
 
 func (l *jsonReferenceLoader) loadFromFile(path string) (interface{}, error) {

--- a/schema.go
+++ b/schema.go
@@ -891,6 +891,7 @@ func (d *Schema) parseReference(documentNode interface{}, currentSchema *subSche
 	newSchema.id = currentSchema.ref
 
 	refdDocumentNode = dsp.Document
+	newSchema.draft = dsp.Draft
 
 	if err != nil {
 		return err

--- a/schemaLoader.go
+++ b/schemaLoader.go
@@ -59,10 +59,12 @@ func (sl *SchemaLoader) validateMetaschema(documentNode interface{}) error {
 			sl.Draft = *draft
 		}
 	}
-	if sl.Draft == Hybrid {
-		return nil
-	}
+
+	// If no explicit "$schema" is used, use the default metaschema associated with the draft used
 	if schema == "" {
+		if sl.Draft == Hybrid {
+			return nil
+		}
 		schema = drafts.GetSchemaURL(sl.Draft)
 	}
 

--- a/schemaLoader.go
+++ b/schemaLoader.go
@@ -1,3 +1,17 @@
+// Copyright 2018 johandorland ( https://github.com/johandorland )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gojsonschema
 
 import (
@@ -21,7 +35,7 @@ func NewSchemaLoader() *SchemaLoader {
 			schemaPoolDocuments: make(map[string]*schemaPoolDocument),
 		},
 		AutoDetect: true,
-		Validate:   true,
+		Validate:   false,
 		Draft:      Hybrid,
 	}
 	ps.pool.autoDetect = &ps.AutoDetect
@@ -171,7 +185,7 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 		}
 	}
 
-	err = d.parse(doc, sl.Draft, sl.AutoDetect)
+	err = d.parse(doc, sl.Draft)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaLoader.go
+++ b/schemaLoader.go
@@ -1,11 +1,18 @@
 package gojsonschema
 
 import (
+	"bytes"
+	"errors"
+	"reflect"
+
 	"github.com/xeipuuv/gojsonreference"
 )
 
 type SchemaLoader struct {
-	pool *schemaPool
+	pool       *schemaPool
+	AutoDetect bool
+	Validate   bool
+	Draft      Draft
 }
 
 func NewSchemaLoader() *SchemaLoader {
@@ -14,9 +21,74 @@ func NewSchemaLoader() *SchemaLoader {
 		pool: &schemaPool{
 			schemaPoolDocuments: make(map[string]*schemaPoolDocument),
 		},
+		AutoDetect: true,
+		Validate:   true,
+		Draft:      Hybrid,
 	}
 
 	return ps
+}
+
+func (sl *SchemaLoader) validateMetaschema(documentNode interface{}) error {
+
+	if isKind(documentNode, reflect.Bool) {
+		return nil
+	}
+	m := documentNode.(map[string]interface{})
+
+	var schema string
+	if existsMapKey(m, KEY_SCHEMA) {
+		if !isKind(m[KEY_SCHEMA], reflect.String) {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfType(),
+				ErrorDetails{
+					"key":  KEY_SCHEMA,
+					"type": TYPE_STRING,
+				},
+			))
+		}
+
+		schemaReference, err := gojsonreference.NewJsonReference(m[KEY_SCHEMA].(string))
+		if err != nil {
+			return err
+		}
+		schema = schemaReference.String()
+		if sl.AutoDetect {
+			if s, ok := schemaDict[schema]; ok {
+				sl.Draft = s
+			}
+		}
+	}
+	if sl.Draft == Hybrid {
+		return nil
+	}
+	if schema == "" {
+		schema = draftDict[sl.Draft]
+	}
+
+	//Disable validation when loading the metaschema to prevent an infinite recursive loop
+	sl.Validate = false
+
+	metaSchema, err := sl.Compile(NewReferenceLoader(schema))
+
+	if err != nil {
+		return err
+	}
+
+	sl.Validate = true
+
+	result := metaSchema.validateDocument(documentNode)
+
+	if !result.Valid() {
+		var res bytes.Buffer
+		for _, err := range result.Errors() {
+			res.WriteString(err.String())
+			res.WriteString("\n")
+		}
+		return errors.New(res.String())
+	}
+
+	return nil
 }
 
 // AddSchemas adds an arbritrary amount of schemas to the schema cache. As this function does not require
@@ -26,9 +98,17 @@ func (sl *SchemaLoader) AddSchemas(loaders ...JSONLoader) error {
 
 	for _, loader := range loaders {
 		doc, err := loader.LoadJSON()
+
 		if err != nil {
 			return err
 		}
+
+		if sl.Validate {
+			if err := sl.validateMetaschema(doc); err != nil {
+				return err
+			}
+		}
+
 		// Directly use the Recursive function, so that it get only added to the schema pool by $id
 		// and not by the ref of the document as it's empty
 		if err = sl.pool.parseReferencesRecursive(doc, emptyRef); err != nil {
@@ -52,6 +132,12 @@ func (sl *SchemaLoader) AddSchema(url string, loader JSONLoader) error {
 
 	if err != nil {
 		return err
+	}
+
+	if sl.Validate {
+		if err := sl.validateMetaschema(doc); err != nil {
+			return err
+		}
 	}
 
 	return sl.pool.ParseReferences(doc, ref)
@@ -93,7 +179,13 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 		}
 	}
 
-	err = d.parse(doc)
+	if sl.Validate {
+		if err := sl.validateMetaschema(doc); err != nil {
+			return nil, err
+		}
+	}
+
+	err = d.parse(doc, sl.Draft, sl.AutoDetect)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaLoader.go
+++ b/schemaLoader.go
@@ -47,16 +47,12 @@ func (sl *SchemaLoader) validateMetaschema(documentNode interface{}) error {
 
 	var (
 		schema string
-		draft  *Draft
 		err    error
 	)
 	if sl.AutoDetect {
-		schema, draft, err = parseSchemaURL(documentNode)
+		schema, _, err = parseSchemaURL(documentNode)
 		if err != nil {
 			return err
-		}
-		if draft != nil {
-			sl.Draft = *draft
 		}
 	}
 
@@ -187,7 +183,18 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 		}
 	}
 
-	err = d.parse(doc, sl.Draft)
+	draft := sl.Draft
+	if sl.AutoDetect {
+		_, detectedDraft, err := parseSchemaURL(doc)
+		if err != nil {
+			return nil, err
+		}
+		if detectedDraft != nil {
+			draft = *detectedDraft
+		}
+	}
+
+	err = d.parse(doc, draft)
 	if err != nil {
 		return nil, err
 	}

--- a/schemaLoader_test.go
+++ b/schemaLoader_test.go
@@ -72,3 +72,37 @@ func TestDoubleIDReference(t *testing.T) {
 	err = ps.AddSchemas(NewStringLoader(`{ "$id" : "http://localhost:1234/test4.json"}`))
 	assert.NotNil(t, err)
 }
+
+func TestCustomMetaSchema(t *testing.T) {
+	// Test a custom metaschema in which we disallow the use of the keyword "multipleOf"
+	ps := NewSchemaLoader()
+	ps.Validate = true
+	err := ps.AddSchemas(NewStringLoader(`{
+		"$id" : "http://localhost:1234/test5.json",
+		"properties" : {
+			"multipleOf" : false
+		}
+	}`))
+	assert.Nil(t, err)
+	_, err = ps.Compile(NewStringLoader(`{
+		"$id" : "http://localhost:1234/test6.json",
+		"$schema" : "http://localhost:1234/test5.json",
+		"type" : "string"
+	}`))
+	assert.Nil(t, err)
+
+	ps = NewSchemaLoader()
+	ps.Validate = true
+	err = ps.AddSchemas(NewStringLoader(`{
+		"$id" : "http://localhost:1234/test5.json",
+		"properties" : {
+			"multipleOf" : false
+		}
+	}`))
+	_, err = ps.Compile(NewStringLoader(`{
+		"$id" : "http://localhost:1234/test7.json",
+		"$schema" : "http://localhost:1234/test5.json",
+		"multipleOf" : 5
+	}`))
+	assert.NotNil(t, err)
+}

--- a/schemaLoader_test.go
+++ b/schemaLoader_test.go
@@ -1,3 +1,17 @@
+// Copyright 2018 johandorland ( https://github.com/johandorland )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gojsonschema
 
 import (

--- a/schemaPool.go
+++ b/schemaPool.go
@@ -36,6 +36,7 @@ import (
 
 type schemaPoolDocument struct {
 	Document interface{}
+	Draft    Draft
 }
 
 type schemaPool struct {
@@ -166,7 +167,7 @@ func (p *schemaPool) GetDocument(reference gojsonreference.JsonReference) (*sche
 			internalLog(" From pool")
 		}
 
-		spd = &schemaPoolDocument{Document: document}
+		spd = &schemaPoolDocument{Document: document, Draft: cachedSpd.Draft}
 		p.schemaPoolDocuments[reference.String()] = spd
 
 		return spd, nil

--- a/subSchema.go
+++ b/subSchema.go
@@ -79,6 +79,7 @@ const (
 )
 
 type subSchema struct {
+	draft *Draft
 
 	// basic subSchema meta properties
 	id          *gojsonreference.JsonReference

--- a/subSchema.go
+++ b/subSchema.go
@@ -105,9 +105,9 @@ type subSchema struct {
 	// validation : number / integer
 	multipleOf       *big.Float
 	maximum          *big.Float
-	exclusiveMaximum bool
+	exclusiveMaximum *big.Float
 	minimum          *big.Float
-	exclusiveMinimum bool
+	exclusiveMinimum *big.Float
 
 	// validation : string
 	minLength *int

--- a/validation.go
+++ b/validation.go
@@ -859,56 +859,54 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 
 	//maximum & exclusiveMaximum:
 	if currentSubSchema.maximum != nil {
-		if currentSubSchema.exclusiveMaximum {
-			if float64Value.Cmp(currentSubSchema.maximum) >= 0 {
-				result.addInternalError(
-					new(NumberLTError),
-					context,
-					resultErrorFormatJsonNumber(number),
-					ErrorDetails{
-						"max": currentSubSchema.maximum,
-					},
-				)
-			}
-		} else {
-			if float64Value.Cmp(currentSubSchema.maximum) == 1 {
-				result.addInternalError(
-					new(NumberLTEError),
-					context,
-					resultErrorFormatJsonNumber(number),
-					ErrorDetails{
-						"max": currentSubSchema.maximum,
-					},
-				)
-			}
+		if float64Value.Cmp(currentSubSchema.maximum) == 1 {
+			result.addInternalError(
+				new(NumberLTEError),
+				context,
+				resultErrorFormatJsonNumber(number),
+				ErrorDetails{
+					"max": currentSubSchema.maximum,
+				},
+			)
+		}
+	}
+	if currentSubSchema.exclusiveMaximum != nil {
+		if float64Value.Cmp(currentSubSchema.exclusiveMaximum) >= 0 {
+			result.addInternalError(
+				new(NumberLTError),
+				context,
+				resultErrorFormatJsonNumber(number),
+				ErrorDetails{
+					"max": currentSubSchema.exclusiveMaximum,
+				},
+			)
 		}
 	}
 
 	//minimum & exclusiveMinimum:
 	if currentSubSchema.minimum != nil {
-		if currentSubSchema.exclusiveMinimum {
-			if float64Value.Cmp(currentSubSchema.minimum) <= 0 {
-				// if float64Value <= *currentSubSchema.minimum {
-				result.addInternalError(
-					new(NumberGTError),
-					context,
-					resultErrorFormatJsonNumber(number),
-					ErrorDetails{
-						"min": currentSubSchema.minimum,
-					},
-				)
-			}
-		} else {
-			if float64Value.Cmp(currentSubSchema.minimum) == -1 {
-				result.addInternalError(
-					new(NumberGTEError),
-					context,
-					resultErrorFormatJsonNumber(number),
-					ErrorDetails{
-						"min": currentSubSchema.minimum,
-					},
-				)
-			}
+		if float64Value.Cmp(currentSubSchema.minimum) == -1 {
+			result.addInternalError(
+				new(NumberGTEError),
+				context,
+				resultErrorFormatJsonNumber(number),
+				ErrorDetails{
+					"min": currentSubSchema.minimum,
+				},
+			)
+		}
+	}
+	if currentSubSchema.exclusiveMinimum != nil {
+		if float64Value.Cmp(currentSubSchema.exclusiveMinimum) <= 0 {
+			// if float64Value <= *currentSubSchema.minimum {
+			result.addInternalError(
+				new(NumberGTError),
+				context,
+				resultErrorFormatJsonNumber(number),
+				ErrorDetails{
+					"min": currentSubSchema.exclusiveMinimum,
+				},
+			)
 		}
 	}
 


### PR DESCRIPTION
Draft-06 and draft-07 were implemented in a way that the API was unchanged, as it was quite limited. New features introduced in these drafts were basically tagged on the draft-04 functionality, without providing an API to distinguish between all these different drafts, creating some sort of hybrid draft.

With the recent addition of `SchemaLoader` we can provide a way of distinguishing between different drafts. This PR adds support for:
* Explicit support for draft-04, draft-06, draft-07 and a hybrid mode. 
* Automatic detection of different drafts using `$schema`
* Draft cross-referencing support. A draft-04 schema can reference a draft-07 schema and both schemas will be parsed according to their appropriate draft version
* Validation of the input schema by validating them against the used draft's metaschema, or in case of a custom `$schema`, that particular custom schema.
* Local caching of metaschemas, so metaschema validation can be done offline.

This is still a WIP, documentation needs to be updated and any feedback on the code is very much appreciated as I'm not quite satisfied with it yet.