### PR TITLE
Add only not unique items into result errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -81,7 +81,7 @@ type (
 		ResultErrorFields
 	}
 
-	// ItemsMustBeUniqueError. ErrorDetails: type
+	// ItemsMustBeUniqueError. ErrorDetails: type, i, j
 	ItemsMustBeUniqueError struct {
 		ResultErrorFields
 	}

--- a/locales.go
+++ b/locales.go
@@ -147,7 +147,7 @@ func (l DefaultLocale) ArrayMaxItems() string {
 }
 
 func (l DefaultLocale) Unique() string {
-	return `{{.type}} items must be unique`
+	return `{{.type}} items[{{.i}},{{.j}}] must be unique`
 }
 
 func (l DefaultLocale) ArrayContains() string {

--- a/utils.go
+++ b/utils.go
@@ -62,6 +62,16 @@ func isStringInSlice(s []string, what string) bool {
 	return false
 }
 
+// indexStringInSlice returns the index of the first instance of 'what' in s or -1 if it is not found in s.
+func indexStringInSlice(s []string, what string) int {
+	for i := range s {
+		if s[i] == what {
+			return i
+		}
+	}
+	return -1
+}
+
 func marshalToJsonString(value interface{}) (*string, error) {
 
 	mBytes, err := json.Marshal(value)

--- a/validation.go
+++ b/validation.go
@@ -517,17 +517,17 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 	// uniqueItems:
 	if currentSubSchema.uniqueItems {
 		var stringifiedItems []string
-		for _, v := range value {
+		for j, v := range value {
 			vString, err := marshalWithoutNumber(v)
 			if err != nil {
 				result.addInternalError(new(InternalError), context, value, ErrorDetails{"err": err})
 			}
-			if isStringInSlice(stringifiedItems, *vString) {
+			if i := indexStringInSlice(stringifiedItems, *vString); i > -1 {
 				result.addInternalError(
 					new(ItemsMustBeUniqueError),
 					context,
 					value,
-					ErrorDetails{"type": TYPE_ARRAY},
+					ErrorDetails{"type": TYPE_ARRAY, "i": i, "j": j},
 				)
 			}
 			stringifiedItems = append(stringifiedItems, *vString)


### PR DESCRIPTION
If you try to validate the following json:

```
[{"foo":"bar"},{"foo":"bar"},{"foo":"baz"}]
```

with the schema:

```
{"uniqueItems":true}
```

then all unique and not unique items will be added to the result errors.
For example:

```
func TestJsonSchema(t *testing.T) {
   data := `[{"foo":"bar"},{"foo":"bar"},{"foo":"baz"}]`
   schema := `{"uniqueItems":true}`

   schemaLoader := gojsonschema.NewStringLoader(schema)
   documentLoader := gojsonschema.NewStringLoader(data)

   // validate
   result, err := gojsonschema.Validate(schemaLoader, documentLoader)
   if err != nil {
      t.Errorf("Error (%s)\n", err.Error())
   }

   for _, vErr := range result.Errors() {
      fmt.Printf("  Value: %s\n", vErr.Value())
   }
   // Output
   // Value: [map[foo:bar] map[foo:bar] map[foo:baz]]
}
```

Although, in my opinion is more logical to add only non-unique elements into result errors.

This commit fixes it and the result will be:

```
// Output
// Value: [map[foo:bar]]
```