### PR TITLE
Fix multipleOf by using arbritrary precision big.Rat instead of big.Float

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -453,7 +453,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 				},
 			))
 		}
-		if multipleOfValue.Cmp(big.NewFloat(0)) <= 0 {
+		if multipleOfValue.Cmp(big.NewRat(0, 1)) <= 0 {
 			return errors.New(formatErrorDescription(
 				Locale.GreaterThanZero(),
 				ErrorDetails{"number": KEY_MULTIPLE_OF},

--- a/subSchema.go
+++ b/subSchema.go
@@ -103,11 +103,11 @@ type subSchema struct {
 	propertiesChildren          []*subSchema
 
 	// validation : number / integer
-	multipleOf       *big.Float
-	maximum          *big.Float
-	exclusiveMaximum *big.Float
-	minimum          *big.Float
-	exclusiveMinimum *big.Float
+	multipleOf       *big.Rat
+	maximum          *big.Rat
+	exclusiveMaximum *big.Rat
+	minimum          *big.Rat
+	exclusiveMinimum *big.Rat
 
 	// validation : string
 	minLength *int

--- a/utils.go
+++ b/utils.go
@@ -120,7 +120,7 @@ func checkJsonInteger(what interface{}) (isInt bool) {
 
 	jsonNumber := what.(json.Number)
 
-	bigFloat, isValidNumber := new(big.Float).SetString(string(jsonNumber))
+	bigFloat, isValidNumber := new(big.Rat).SetString(string(jsonNumber))
 
 	return isValidNumber && bigFloat.IsInt()
 
@@ -168,11 +168,11 @@ func mustBeInteger(what interface{}) *int {
 	return nil
 }
 
-func mustBeNumber(what interface{}) *big.Float {
+func mustBeNumber(what interface{}) *big.Rat {
 
 	if isJsonNumber(what) {
 		number := what.(json.Number)
-		float64Value, success := new(big.Float).SetString(string(number))
+		float64Value, success := new(big.Rat).SetString(string(number))
 		if success {
 			return float64Value
 		} else {

--- a/validation.go
+++ b/validation.go
@@ -842,17 +842,16 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 	}
 
 	number := value.(json.Number)
-	float64Value, _ := new(big.Float).SetString(string(number))
+	float64Value, _ := new(big.Rat).SetString(string(number))
 
 	// multipleOf:
 	if currentSubSchema.multipleOf != nil {
-
-		if q := new(big.Float).Quo(float64Value, currentSubSchema.multipleOf); !q.IsInt() {
+		if q := new(big.Rat).Quo(float64Value, currentSubSchema.multipleOf); !q.IsInt() {
 			result.addInternalError(
 				new(MultipleOfError),
 				context,
 				resultErrorFormatJsonNumber(number),
-				ErrorDetails{"multiple": currentSubSchema.multipleOf},
+				ErrorDetails{"multiple": new(big.Float).SetRat(currentSubSchema.multipleOf)},
 			)
 		}
 	}


### PR DESCRIPTION
This should solve all `multipleOf` problems once and for all 🤞. Fixes #223 