### PR TITLE
Custom Validate Options (Format Checkers)

### DIFF
--- a/format_checkers.go
+++ b/format_checkers.go
@@ -122,6 +122,18 @@ var (
 	lock = new(sync.Mutex)
 )
 
+func NewFormatCheckers() *FormatCheckerChain {
+	return &FormatCheckerChain{formatters: map[string]FormatChecker{}}
+}
+
+func NewDefaultFormatCheckers() *FormatCheckerChain {
+	formats := NewFormatCheckers()
+	for k, v := range FormatCheckers.formatters {
+		formats.formatters[k] = v
+	}
+	return formats
+}
+
 // Add adds a FormatChecker to the FormatCheckerChain
 // The name used will be the value used for the format key in your json schema
 func (c *FormatCheckerChain) Add(name string, f FormatChecker) *FormatCheckerChain {

--- a/format_checkers_test.go
+++ b/format_checkers_test.go
@@ -1,8 +1,9 @@
 package gojsonschema
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUUIDFormatCheckerIsFormat(t *testing.T) {

--- a/schema.go
+++ b/schema.go
@@ -669,7 +669,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 
 	if existsMapKey(m, KEY_FORMAT) {
 		formatString, ok := m[KEY_FORMAT].(string)
-		if ok && FormatCheckers.Has(formatString) {
+		if ok {
 			currentSchema.format = formatString
 		}
 	}


### PR DESCRIPTION
Added ValidateOptions, allows you run each validate cycle without changing schema and global state. 

ValidateOptions currently contains only FormatCheckes you can pass yo validate without changing of global FormatChackers or compiled schema. So you can define custom checkers that not only validate but also have perfom document local actions. For example, count properties of some format.