### PR TITLE
fundamental SnapAV mods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.sw[nop]
 *.iml
 .vscode/
+*.idea

--- a/draft.go
+++ b/draft.go
@@ -19,7 +19,7 @@ import (
 	"math"
 	"reflect"
 
-	"github.com/xeipuuv/gojsonreference"
+	"github.com/Snap-AV/gojsonschema/gojsonreference"
 )
 
 type Draft int

--- a/gojsonpointer/pointer.go
+++ b/gojsonpointer/pointer.go
@@ -1,0 +1,211 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author  			xeipuuv
+// author-github 	https://github.com/xeipuuv
+// author-mail		xeipuuv@gmail.com
+//
+// repository-name	gojsonpointer
+// repository-desc	An implementation of JSON Pointer - Go language
+//
+// description		Main and unique file.
+//
+// created      	25-02-2013
+
+package gojsonpointer
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+const (
+	const_empty_pointer     = ``
+	const_pointer_separator = `/`
+
+	const_invalid_start = `JSON pointer must be empty or start with a "` + const_pointer_separator + `"`
+)
+
+type implStruct struct {
+	mode string // "SET" or "GET"
+
+	inDocument interface{}
+
+	setInValue interface{}
+
+	getOutNode interface{}
+	getOutKind reflect.Kind
+	outError   error
+}
+
+type JsonPointer struct {
+	referenceTokens []string
+}
+
+// NewJsonPointer parses the given string JSON pointer and returns an object
+func NewJsonPointer(jsonPointerString string) (p JsonPointer, err error) {
+
+	// Pointer to the root of the document
+	if len(jsonPointerString) == 0 {
+		// Keep referenceTokens nil
+		return
+	}
+	if jsonPointerString[0] != '/' {
+		return p, errors.New(const_invalid_start)
+	}
+
+	p.referenceTokens = strings.Split(jsonPointerString[1:], const_pointer_separator)
+	return
+}
+
+// Uses the pointer to retrieve a value from a JSON document
+func (p *JsonPointer) Get(document interface{}) (interface{}, reflect.Kind, error) {
+
+	is := &implStruct{mode: "GET", inDocument: document}
+	p.implementation(is)
+	return is.getOutNode, is.getOutKind, is.outError
+
+}
+
+// Uses the pointer to update a value from a JSON document
+func (p *JsonPointer) Set(document interface{}, value interface{}) (interface{}, error) {
+
+	is := &implStruct{mode: "SET", inDocument: document, setInValue: value}
+	p.implementation(is)
+	return document, is.outError
+
+}
+
+// Uses the pointer to delete a value from a JSON document
+func (p *JsonPointer) Delete(document interface{}) (interface{}, error) {
+	is := &implStruct{mode: "DEL", inDocument: document}
+	p.implementation(is)
+	return document, is.outError
+}
+
+// Both Get and Set functions use the same implementation to avoid code duplication
+func (p *JsonPointer) implementation(i *implStruct) {
+
+	kind := reflect.Invalid
+
+	// Full document when empty
+	if len(p.referenceTokens) == 0 {
+		i.getOutNode = i.inDocument
+		i.outError = nil
+		i.getOutKind = kind
+		i.outError = nil
+		return
+	}
+
+	node := i.inDocument
+
+	previousNodes := make([]interface{}, len(p.referenceTokens))
+	previousTokens := make([]string, len(p.referenceTokens))
+
+	for ti, token := range p.referenceTokens {
+
+		isLastToken := ti == len(p.referenceTokens)-1
+		previousNodes[ti] = node
+		previousTokens[ti] = token
+
+		switch v := node.(type) {
+
+		case map[string]interface{}:
+			decodedToken := decodeReferenceToken(token)
+			if _, ok := v[decodedToken]; ok {
+				node = v[decodedToken]
+				if isLastToken && i.mode == "SET" {
+					v[decodedToken] = i.setInValue
+				} else if isLastToken && i.mode =="DEL" {
+					delete(v,decodedToken)
+				}
+			} else if (isLastToken && i.mode == "SET") {
+				v[decodedToken] = i.setInValue
+			} else {
+				i.outError = fmt.Errorf("Object has no key '%s'", decodedToken)
+				i.getOutKind = reflect.Map
+				i.getOutNode = nil
+				return
+			}
+
+		case []interface{}:
+			tokenIndex, err := strconv.Atoi(token)
+			if err != nil {
+				i.outError = fmt.Errorf("Invalid array index '%s'", token)
+				i.getOutKind = reflect.Slice
+				i.getOutNode = nil
+				return
+			}
+			if tokenIndex < 0 || tokenIndex >= len(v) {
+				i.outError = fmt.Errorf("Out of bound array[0,%d] index '%d'", len(v), tokenIndex)
+				i.getOutKind = reflect.Slice
+				i.getOutNode = nil
+				return
+			}
+
+			node = v[tokenIndex]
+			if isLastToken && i.mode == "SET" {
+				v[tokenIndex] = i.setInValue
+			}  else if isLastToken && i.mode =="DEL" {
+				v[tokenIndex] = v[len(v)-1]
+				v[len(v)-1] = nil
+				v = v[:len(v)-1]
+				previousNodes[ti-1].(map[string]interface{})[previousTokens[ti-1]] = v
+			}
+
+		default:
+			i.outError = fmt.Errorf("Invalid token reference '%s'", token)
+			i.getOutKind = reflect.ValueOf(node).Kind()
+			i.getOutNode = nil
+			return
+		}
+
+	}
+
+	i.getOutNode = node
+	i.getOutKind = reflect.ValueOf(node).Kind()
+	i.outError = nil
+}
+
+// Pointer to string representation function
+func (p *JsonPointer) String() string {
+
+	if len(p.referenceTokens) == 0 {
+		return const_empty_pointer
+	}
+
+	pointerString := const_pointer_separator + strings.Join(p.referenceTokens, const_pointer_separator)
+
+	return pointerString
+}
+
+// Specific JSON pointer encoding here
+// ~0 => ~
+// ~1 => /
+// ... and vice versa
+
+func decodeReferenceToken(token string) string {
+	step1 := strings.Replace(token, `~1`, `/`, -1)
+	step2 := strings.Replace(step1, `~0`, `~`, -1)
+	return step2
+}
+
+func encodeReferenceToken(token string) string {
+	step1 := strings.Replace(token, `~`, `~0`, -1)
+	step2 := strings.Replace(step1, `/`, `~1`, -1)
+	return step2
+}

--- a/gojsonreference/reference.go
+++ b/gojsonreference/reference.go
@@ -1,0 +1,147 @@
+// Copyright 2015 xeipuuv ( https://github.com/xeipuuv )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// author  			xeipuuv
+// author-github 	https://github.com/xeipuuv
+// author-mail		xeipuuv@gmail.com
+//
+// repository-name	gojsonreference
+// repository-desc	An implementation of JSON Reference - Go language
+//
+// description		Main and unique file.
+//
+// created      	26-02-2013
+
+package gojsonreference
+
+import (
+	"errors"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/Snap-AV/gojsonschema/gojsonpointer"
+)
+
+const (
+	const_fragment_char = `#`
+)
+
+func NewJsonReference(jsonReferenceString string) (JsonReference, error) {
+
+	var r JsonReference
+	err := r.parse(jsonReferenceString)
+	return r, err
+
+}
+
+type JsonReference struct {
+	referenceUrl     *url.URL
+	referencePointer gojsonpointer.JsonPointer
+
+	HasFullUrl      bool
+	HasUrlPathOnly  bool
+	HasFragmentOnly bool
+	HasFileScheme   bool
+	HasFullFilePath bool
+}
+
+func (r *JsonReference) GetUrl() *url.URL {
+	return r.referenceUrl
+}
+
+func (r *JsonReference) GetPointer() *gojsonpointer.JsonPointer {
+	return &r.referencePointer
+}
+
+func (r *JsonReference) String() string {
+
+	if r.referenceUrl != nil {
+		return r.referenceUrl.String()
+	}
+
+	if r.HasFragmentOnly {
+		return const_fragment_char + r.referencePointer.String()
+	}
+
+	return r.referencePointer.String()
+}
+
+func (r *JsonReference) IsCanonical() bool {
+	return (r.HasFileScheme && r.HasFullFilePath) || (!r.HasFileScheme && r.HasFullUrl)
+}
+
+// "Constructor", parses the given string JSON reference
+func (r *JsonReference) parse(jsonReferenceString string) (err error) {
+
+	r.referenceUrl, err = url.Parse(jsonReferenceString)
+	if err != nil {
+		return
+	}
+	refUrl := r.referenceUrl
+
+	if refUrl.Scheme != "" && refUrl.Host != "" {
+		r.HasFullUrl = true
+	} else {
+		if refUrl.Path != "" {
+			r.HasUrlPathOnly = true
+		} else if refUrl.RawQuery == "" && refUrl.Fragment != "" {
+			r.HasFragmentOnly = true
+		}
+	}
+
+	r.HasFileScheme = refUrl.Scheme == "file"
+	if runtime.GOOS == "windows" {
+		// on Windows, a file URL may have an extra leading slash, and if it
+		// doesn't then its first component will be treated as the host by the
+		// Go runtime
+		if refUrl.Host == "" && strings.HasPrefix(refUrl.Path, "/") {
+			r.HasFullFilePath = filepath.IsAbs(refUrl.Path[1:])
+		} else {
+			r.HasFullFilePath = filepath.IsAbs(refUrl.Host + refUrl.Path)
+		}
+	} else {
+		r.HasFullFilePath = filepath.IsAbs(refUrl.Path)
+	}
+
+	// invalid json-pointer error means url has no json-pointer fragment. simply ignore error
+	r.referencePointer, _ = gojsonpointer.NewJsonPointer(refUrl.Fragment)
+
+	return
+}
+
+// Creates a new reference from a parent and a child
+// If the child cannot inherit from the parent, an error is returned
+func (r *JsonReference) Inherits(child JsonReference) (*JsonReference, error) {
+	if child.GetUrl() == nil {
+		return nil, errors.New("childUrl is nil!")
+	}
+
+	if r.GetUrl() == nil {
+		return nil, errors.New("parentUrl is nil!")
+	}
+
+	// Get a copy of the parent url to make sure we do not modify the original.
+	// URL reference resolving fails if the fragment of the child is empty, but the parent's is not.
+	// The fragment of the child must be used, so the fragment of the parent is manually removed.
+	parentUrl := *r.GetUrl()
+	parentUrl.Fragment = ""
+
+	ref, err := NewJsonReference(parentUrl.ResolveReference(child.GetUrl()).String())
+	if err != nil {
+		return nil, err
+	}
+	return &ref, err
+}

--- a/jsonLoader.go
+++ b/jsonLoader.go
@@ -38,7 +38,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/xeipuuv/gojsonreference"
+	"github.com/Snap-AV/gojsonschema/gojsonreference"
 )
 
 var osFS = osFileSystem(os.Open)

--- a/result.go
+++ b/result.go
@@ -69,7 +69,8 @@ type (
 		errors []ResultError
 		// Scores how well the validation matched. Useful in generating
 		// better error messages for anyOf and oneOf.
-		score int
+		score  int
+		output map[string]interface{}
 	}
 )
 
@@ -158,6 +159,10 @@ func (v *Result) Valid() bool {
 
 func (v *Result) Errors() []ResultError {
 	return v.errors
+}
+
+func (v *Result) Output() map[string]interface{} {
+	return v.output
 }
 
 // Add a fully filled error to the error set

--- a/schema.go
+++ b/schema.go
@@ -33,7 +33,7 @@ import (
 	"regexp"
 	"text/template"
 
-	"github.com/xeipuuv/gojsonreference"
+	"github.com/Snap-AV/gojsonschema/gojsonreference"
 )
 
 var (

--- a/schemaLoader.go
+++ b/schemaLoader.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"errors"
 
-	"github.com/xeipuuv/gojsonreference"
+	"github.com/Snap-AV/gojsonschema/gojsonreference"
 )
 
 type SchemaLoader struct {

--- a/schemaPool.go
+++ b/schemaPool.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/xeipuuv/gojsonreference"
+	"github.com/Snap-AV/gojsonschema/gojsonreference"
 )
 
 type schemaPoolDocument struct {

--- a/subSchema.go
+++ b/subSchema.go
@@ -32,7 +32,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/xeipuuv/gojsonreference"
+	"github.com/Snap-AV/gojsonschema/gojsonreference"
 )
 
 const (

--- a/validation.go
+++ b/validation.go
@@ -70,6 +70,7 @@ func (v *Schema) validateDocument(root interface{}) *Result {
 	result := &Result{}
 	context := NewJsonContext(STRING_CONTEXT_ROOT, nil)
 	v.rootSchema.validateRecursive(v.rootSchema, root, result, context)
+	result.output = root.(map[string]interface{})
 
 	return result
 }
@@ -646,12 +647,15 @@ func (v *subSchema) validateObject(currentSubSchema *subSchema, value map[string
 					} else {
 
 						if !pp_has || !pp_match {
-							result.addInternalError(
-								new(AdditionalPropertyNotAllowedError),
-								context,
-								value[pk],
-								ErrorDetails{"property": pk},
-							)
+							delete(value, pk)
+							/*
+								result.addInternalError(
+									new(AdditionalPropertyNotAllowedError),
+									context,
+									value[pk],
+									ErrorDetails{"property": pk},
+								)
+							*/
 						}
 
 					}


### PR DESCRIPTION
These are the initial mods after forking this repo from xeipuuv/gojsonschema.  It has the following changes:

* As usual, I deplore IDE files being included in the repo.  So I updated .gitignore to ignore them.
* The "Result" structure was modified to include an "output" parameter.  This parameter holds the JSON map after any modifications have been made to the input map during validation.
* The "Result" structure now has an Output() method to retrieve the output JSON map.
* The processing for "additionalProperties" was modified to delete any properties that are not included in the schema if "additionalProperties" is set to false.  It does not return an error.
* The external dependencies of the forked repo (xeipuuv/goschemareferences and xeipuuv/goschemapointers) were bought in as sub-packages to the SnapAV version of the repo.