### PR TITLE
CI: add Go 1.11, 1.12, and remove Go < 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: go
 go:
-  - "1.5"
-  - "1.6"
-  - "1.7"
-  - "1.8"
-  - "1.9"
   - "1.10"
+  - "1.11"
+  - "1.12"
 before_install:
   - go get github.com/xeipuuv/gojsonreference
   - go get github.com/xeipuuv/gojsonpointer

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Not all formats defined in draft-07 are available. Implemented formats are:
 `email`, `uri` and `uri-reference` use the same validation code as their unicode counterparts `idn-email`, `iri` and `iri-reference`. If you rely on unicode support you should use the specific 
 unicode enabled formats for the sake of interoperability as other implementations might not support unicode in the regular formats.
 
-The validation code for `uri`, `idn-email` and their relatives use mostly standard library code. Go 1.5 and 1.6 contain some minor bugs with handling URIs and unicode. You are encouraged to use Go 1.7+ if you rely on these formats.
+The validation code for `uri`, `idn-email` and their relatives use mostly standard library code.
 
 For repetitive or more complex formats, you can create custom format checkers and add them to gojsonschema like this:
 

--- a/jsonschema_test.go
+++ b/jsonschema_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -150,12 +149,6 @@ func TestSuite(t *testing.T) {
 }
 
 func TestFormats(t *testing.T) {
-	// Go 1.5 and 1.6 contain minor bugs in parsing URIs and unicode which makes the test suite fail uri and idn-email formats
-	// Therefore disable these tests for these go versions
-	if strings.HasPrefix(runtime.Version(), "go1.5") || strings.HasPrefix(runtime.Version(), "go1.6") {
-		return
-	}
-
 	wd, err := os.Getwd()
 	if err != nil {
 		panic(err.Error())


### PR DESCRIPTION
I think it might be worth considering to drop Go 1.9 and under, as they've all become EOL, but I'll open a separate pull-request for that