### PR TITLE
Passing Regex Pattern Name to formatErrorDescription

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -655,7 +655,7 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 			if err != nil {
 				return errors.New(formatErrorDescription(
 					Locale.MustBeValidRegex(),
-					ErrorDetails{"key": KEY_PATTERN},
+					ErrorDetails{"key": m[KEY_PATTERN]},
 				))
 			}
 			currentSchema.pattern = regexpObject


### PR DESCRIPTION
Problem:
gojsonschema does not throw a valid error log for Invalid Regex in a schema. This is the current error log.
"pattern must be a valid regex" -> Does not say what is the pattern.

Solution:
This can be resolved by passing the value of map (m[KEY_PATTERN]) instead of [KEY_PATTERN].
