### PR TITLE
Fix extremely slow checking unique items in array

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -503,13 +503,13 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 
 	// uniqueItems:
 	if currentSubSchema.uniqueItems {
-		var stringifiedItems []string
+		var stringifiedItems = make(map[string]int)
 		for j, v := range value {
 			vString, err := marshalWithoutNumber(v)
 			if err != nil {
 				result.addInternalError(new(InternalError), context, value, ErrorDetails{"err": err})
 			}
-			if i := indexStringInSlice(stringifiedItems, *vString); i > -1 {
+			if i, ok := stringifiedItems[*vString]; ok {
 				result.addInternalError(
 					new(ItemsMustBeUniqueError),
 					context,
@@ -517,7 +517,7 @@ func (v *subSchema) validateArray(currentSubSchema *subSchema, value []interface
 					ErrorDetails{"type": TYPE_ARRAY, "i": i, "j": j},
 				)
 			}
-			stringifiedItems = append(stringifiedItems, *vString)
+			stringifiedItems[*vString] = j
 		}
 	}
 


### PR DESCRIPTION
It is nice to check unique items in array with iteration if size of array is small, less than 1k items, but if you have 100k items that starts working extremely slow

```
Showing top 10 nodes out of 50
      flat  flat%   sum%        cum   cum%
     2.19s 45.53% 45.53%      2.19s 45.53%  memeqbody
     1.86s 38.67% 84.20%      4.36s 90.64%  service/vendor/github.com/xeipuuv/gojsonschema.isStringInSlice
     0.31s  6.44% 90.64%      0.31s  6.44%  runtime.memequal
     0.15s  3.12% 93.76%      0.18s  3.74%  encoding/json.(*encodeState).marshal
     0.03s  0.62% 94.39%      0.03s  0.62%  runtime.stkbucket
     0.02s  0.42% 94.80%      0.11s  2.29%  runtime.mallocgc
     0.02s  0.42% 95.22%      0.03s  0.62%  runtime.newstack
     0.01s  0.21% 95.43%      0.03s  0.62%  encoding/json.(*encodeState).reflectValue
     0.01s  0.21% 95.63%      4.67s 97.09%  service/vendor/github.com/xeipuuv/gojsonschema.(*subSchema).validateArray
     0.01s  0.21% 95.84%      0.03s  0.62%  math/big.(*Float).scan
(pprof) list isStringInSlice
Total: 4.81s
ROUTINE ======================== go.avito.ru/service/vendor/github.com/xeipuuv/gojsonschema.isStringInSlice in /Users/valinurovam/repos/avito/service-pro-stats/src/go.avito.ru/service/vendor/github.com/xeipuuv/gojsonschema/utils.go
     1.86s      4.36s (flat, cum) 90.64% of Total
         .          .     52:	_, ok := m[k]
         .          .     53:	return ok
         .          .     54:}
         .          .     55:
         .          .     56:func isStringInSlice(s []string, what string) bool {
     590ms      590ms     57:	for i := range s {
     1.27s      3.77s     58:		if s[i] == what {
         .          .     59:			return true
         .          .     60:		}
         .          .     61:	}
         .          .     62:	return false
         .          .     63:}
(pprof) 
```
Simple pprof output for 50k items in array.
So unique check with map is more predictable.