### PR TITLE
Fix number formatting

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -27,8 +27,6 @@ package gojsonschema
 
 import (
 	"encoding/json"
-	"fmt"
-	"math"
 	"math/big"
 	"reflect"
 )
@@ -132,15 +130,6 @@ const (
 	minJSONFloat = -float64(1<<53 - 1) //-9007199254740991.0	-2^53 - 1
 )
 
-func isFloat64AnInteger(f float64) bool {
-
-	if math.IsNaN(f) || math.IsInf(f, 0) || f < minJSONFloat || f > maxJSONFloat {
-		return false
-	}
-
-	return f == float64(int64(f)) || f == float64(uint64(f))
-}
-
 func mustBeInteger(what interface{}) *int {
 
 	if isJSONNumber(what) {
@@ -177,28 +166,6 @@ func mustBeNumber(what interface{}) *big.Rat {
 
 	return nil
 
-}
-
-// formats a number so that it is displayed as the smallest string possible
-func resultErrorFormatJSONNumber(n json.Number) string {
-
-	if int64Value, err := n.Int64(); err == nil {
-		return fmt.Sprintf("%d", int64Value)
-	}
-
-	float64Value, _ := n.Float64()
-
-	return fmt.Sprintf("%g", float64Value)
-}
-
-// formats a number so that it is displayed as the smallest string possible
-func resultErrorFormatNumber(n float64) string {
-
-	if isFloat64AnInteger(n) {
-		return fmt.Sprintf("%d", int64(n))
-	}
-
-	return fmt.Sprintf("%g", n)
 }
 
 func convertDocumentNode(val interface{}) interface{} {

--- a/utils_test.go
+++ b/utils_test.go
@@ -27,42 +27,10 @@ package gojsonschema
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
-
-func TestResultErrorFormatNumber(t *testing.T) {
-
-	assert.Equal(t, "1", resultErrorFormatNumber(1))
-	assert.Equal(t, "-1", resultErrorFormatNumber(-1))
-	assert.Equal(t, "0", resultErrorFormatNumber(0))
-	// unfortunately, can not be recognized as float
-	assert.Equal(t, "0", resultErrorFormatNumber(0.0))
-
-	assert.Equal(t, "1.001", resultErrorFormatNumber(1.001))
-	assert.Equal(t, "-1.001", resultErrorFormatNumber(-1.001))
-	assert.Equal(t, "0.0001", resultErrorFormatNumber(0.0001))
-
-	// casting math.MaxInt64 (1<<63 -1) to float back to int64
-	// becomes negative. obviousely because of bit missinterpretation.
-	// so simply test a slightly smaller "large" integer here
-	assert.Equal(t, "4.611686018427388e+18", resultErrorFormatNumber(1<<62))
-	// with negative int64 max works
-	assert.Equal(t, "-9.223372036854776e+18", resultErrorFormatNumber(math.MinInt64))
-	assert.Equal(t, "-4.611686018427388e+18", resultErrorFormatNumber(-1<<62))
-
-	assert.Equal(t, "10000000000", resultErrorFormatNumber(1e10))
-	assert.Equal(t, "-10000000000", resultErrorFormatNumber(-1e10))
-
-	assert.Equal(t, "1.000000000001", resultErrorFormatNumber(1.000000000001))
-	assert.Equal(t, "-1.000000000001", resultErrorFormatNumber(-1.000000000001))
-	assert.Equal(t, "1e-10", resultErrorFormatNumber(1e-10))
-	assert.Equal(t, "-1e-10", resultErrorFormatNumber(-1e-10))
-	assert.Equal(t, "4.6116860184273876e+07", resultErrorFormatNumber(4.611686018427387904e7))
-	assert.Equal(t, "-4.6116860184273876e+07", resultErrorFormatNumber(-4.611686018427387904e7))
-
-}
 
 func TestCheckJsonNumber(t *testing.T) {
 	var testCases = []struct {

--- a/validation.go
+++ b/validation.go
@@ -837,8 +837,10 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 			result.addInternalError(
 				new(MultipleOfError),
 				context,
-				resultErrorFormatJSONNumber(number),
-				ErrorDetails{"multiple": new(big.Float).SetRat(currentSubSchema.multipleOf)},
+				number,
+				ErrorDetails{
+					"multiple": new(big.Float).SetRat(currentSubSchema.multipleOf),
+				},
 			)
 		}
 	}
@@ -849,9 +851,9 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 			result.addInternalError(
 				new(NumberLTEError),
 				context,
-				resultErrorFormatJSONNumber(number),
+				number,
 				ErrorDetails{
-					"max": currentSubSchema.maximum,
+					"max": new(big.Float).SetRat(currentSubSchema.maximum),
 				},
 			)
 		}
@@ -861,9 +863,9 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 			result.addInternalError(
 				new(NumberLTError),
 				context,
-				resultErrorFormatJSONNumber(number),
+				number,
 				ErrorDetails{
-					"max": currentSubSchema.exclusiveMaximum,
+					"max": new(big.Float).SetRat(currentSubSchema.exclusiveMaximum),
 				},
 			)
 		}
@@ -875,22 +877,21 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 			result.addInternalError(
 				new(NumberGTEError),
 				context,
-				resultErrorFormatJSONNumber(number),
+				number,
 				ErrorDetails{
-					"min": currentSubSchema.minimum,
+					"min": new(big.Float).SetRat(currentSubSchema.minimum),
 				},
 			)
 		}
 	}
 	if currentSubSchema.exclusiveMinimum != nil {
 		if float64Value.Cmp(currentSubSchema.exclusiveMinimum) <= 0 {
-			// if float64Value <= *currentSubSchema.minimum {
 			result.addInternalError(
 				new(NumberGTError),
 				context,
-				resultErrorFormatJSONNumber(number),
+				number,
 				ErrorDetails{
-					"min": currentSubSchema.exclusiveMinimum,
+					"min": new(big.Float).SetRat(currentSubSchema.exclusiveMinimum),
 				},
 			)
 		}


### PR DESCRIPTION
Return the internal numbers for minimum, maximum, exclusiveminimum and exclusivemaximum as `big.Float` instead of `big.Rat`, which have a proper string representation. Furthermore this PR cleans up some old number handling when bignums were not supported. If an error occurs at a number, `err.Value()` now returns the raw `json.Number` instead of a stringified parsed number value.