### PR TITLE
Refactor format code

### DIFF
--- a/format_checkers.go
+++ b/format_checkers.go
@@ -141,7 +141,7 @@ var (
 
 	rxRelJSONPointer = regexp.MustCompile("^(?:0|[1-9][0-9]*)(?:#|(?:/(?:[^~/]|~0|~1)*)*)$")
 
-	lock = new(sync.Mutex)
+	lock = new(sync.RWMutex)
 )
 
 // Add adds a FormatChecker to the FormatCheckerChain
@@ -165,9 +165,9 @@ func (c *FormatCheckerChain) Remove(name string) *FormatCheckerChain {
 
 // Has checks to see if the FormatCheckerChain holds a FormatChecker with the given name
 func (c *FormatCheckerChain) Has(name string) bool {
-	lock.Lock()
+	lock.RLock()
 	_, ok := c.formatters[name]
-	lock.Unlock()
+	lock.RUnlock()
 
 	return ok
 }
@@ -175,12 +175,13 @@ func (c *FormatCheckerChain) Has(name string) bool {
 // IsFormat will check an input against a FormatChecker with the given name
 // to see if it is the correct format
 func (c *FormatCheckerChain) IsFormat(name string, input interface{}) bool {
-	lock.Lock()
+	lock.RLock()
 	f, ok := c.formatters[name]
-	lock.Unlock()
+	lock.RUnlock()
 
+	// If a format is unrecognized it should always pass validation
 	if !ok {
-		return false
+		return true
 	}
 
 	return f.IsFormat(input)

--- a/schema.go
+++ b/schema.go
@@ -673,9 +673,13 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 
 	if existsMapKey(m, KEY_FORMAT) {
 		formatString, ok := m[KEY_FORMAT].(string)
-		if ok && FormatCheckers.Has(formatString) {
-			currentSchema.format = formatString
+		if !ok {
+			return errors.New(formatErrorDescription(
+				Locale.MustBeOfType(),
+				ErrorDetails{"key": KEY_FORMAT, "type": TYPE_STRING},
+			))
 		}
+		currentSchema.format = formatString
 	}
 
 	// validation : object


### PR DESCRIPTION
- Require the `format` keyword to be of type string, like the JSON schema specification requires.
- Restructure some of the format logic to be handled at validation time instead of schema
parsing time. Previously errors could occur if a format was registered or deleted after a schema is parsed, but before validation. Now it only matters if a formatter is registered at validation time.
- Use a `sync.RWMutex` instead of a regular `sync.Mutex` 