### PR TITLE
Update IsFormat Signature (With Backwards Compatibility!)

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -301,6 +301,9 @@ func newError(err ResultError, context *JsonContext, value interface{}, locale l
 	case *ConditionElseError:
 		t = "condition_else"
 		d = locale.ConditionElse()
+	default:
+		t = err.Type()
+		d = err.DescriptionFormat()
 	}
 
 	err.SetType(t)

--- a/format_checkers_test.go
+++ b/format_checkers_test.go
@@ -1,8 +1,9 @@
 package gojsonschema
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUUIDFormatCheckerIsFormat(t *testing.T) {

--- a/format_checkers_with_error.go
+++ b/format_checkers_with_error.go
@@ -1,0 +1,55 @@
+package gojsonschema
+
+type (
+
+	// FormatCheckerWithError exposes a new interface for IsFormat signature. Ideally, there should be ResultError returned along with IsFmt so users can easily
+	// customize the message. For now, this is a proof of concept. If met with acceptance, then we can slowly deprecate to new definition.
+	FormatCheckerWithError interface {
+		FormatChecker
+		IsFormatWithError(input interface{}) (bool, ResultError)
+	}
+
+	baseFormatCheckerWithError struct {
+		FormatChecker
+	}
+)
+
+var _ FormatCheckerWithError = (*baseFormatCheckerWithError)(nil)
+
+// convertToNewChecker
+func convertToNewChecker(oldChecker FormatChecker) FormatCheckerWithError {
+	newChecker := &baseFormatCheckerWithError{oldChecker}
+	return newChecker
+}
+
+//IsFormatWithError returns whether format is met and corresponding result error. Extends existing FormatCheckers.
+func (b *baseFormatCheckerWithError) IsFormatWithError(input interface{}) (bool, ResultError) {
+	isFmt := b.IsFormat(input)
+	if isFmt {
+		return true, nil
+	}
+
+	return false, new(DoesNotMatchFormatError)
+}
+
+// AddCheckerWithError extends FormatCheckerChain to add this new FormatChecker interface.
+func (c *FormatCheckerChain) AddCheckerWithError(name string, f FormatCheckerWithError) *FormatCheckerChain {
+	lock.Lock()
+	c.formatters[name] = f
+	lock.Unlock()
+	return c
+}
+
+// IsFormatWithError will check if an input matches corresponding format and returns appropriate error associated to it.
+func (c *FormatCheckerChain) IsFormatWithError(name string, input interface{}) (bool, ResultError) {
+	lock.RLock()
+	f, ok := c.formatters[name]
+	lock.RUnlock()
+
+	// If a format is unrecognized it should always pass validation
+	if !ok {
+		return true, nil
+	}
+
+	return f.IsFormatWithError(input)
+}

--- a/format_checkers_with_error_test.go
+++ b/format_checkers_with_error_test.go
@@ -1,0 +1,100 @@
+package gojsonschema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestUUIDFormatCheckerIsFormatWithError(t *testing.T) {
+	checker := convertToNewChecker(UUIDFormatChecker{})
+
+	isRightFmt, err := checker.IsFormatWithError("01234567-89ab-cdef-0123-456789abcdef")
+	assert.True(t, isRightFmt)
+	assert.Nil(t, err)
+
+	isRightFmt, err = checker.IsFormatWithError("f1234567-89ab-cdef-0123-456789abcdef")
+	assert.True(t, isRightFmt)
+	assert.Nil(t, err)
+
+	isRightFmt, err = checker.IsFormatWithError("not-a-uuid")
+	assert.False(t, isRightFmt)
+	assert.NotNil(t, err)
+
+	isRightFmt, err = checker.IsFormatWithError("g1234567-89ab-cdef-0123-456789abcdef")
+	assert.False(t, isRightFmt)
+	assert.NotNil(t, err)
+}
+
+func TestURIReferenceFormatCheckerIsFormatWithError(t *testing.T) {
+	checker := convertToNewChecker(URIReferenceFormatChecker{})
+
+	isRightFmt, err := checker.IsFormatWithError("relative")
+	assert.True(t, isRightFmt)
+	assert.Nil(t, err)
+
+	isRightFmt, err = checker.IsFormatWithError("https://dummyhost.com/dummy-path?dummy-qp-name=dummy-qp-value")
+	assert.True(t, isRightFmt)
+	assert.Nil(t, err)
+
+	assert.True(t, checker.IsFormat("relative"))
+	assert.True(t, checker.IsFormat("https://dummyhost.com/dummy-path?dummy-qp-name=dummy-qp-value"))
+}
+
+type mockChecker struct {
+	mock.Mock
+}
+
+func (c *mockChecker) IsFormat(input interface{}) bool {
+	args := c.Called(input)
+	return args.Bool(0)
+}
+
+func (c *mockChecker) IsFormatWithError(input interface{}) (bool, ResultError) {
+	args := c.Called(input)
+
+	b := args.Bool(0)
+	rerr, ok := args.Get(1).(ResultError)
+	if !ok {
+		return b, nil
+	}
+	return b, rerr
+}
+
+func TestGlobalFormatCheckersWithError(t *testing.T) {
+	checker := convertToNewChecker(UUIDFormatChecker{})
+	fakeFmtTag := "fake"
+	FormatCheckers.Add(fakeFmtTag, checker)
+
+	isRightFmt, err := FormatCheckers.IsFormatWithError(fakeFmtTag, "f1234567-89ab-cdef-0123-456789abcdef")
+	assert.True(t, isRightFmt)
+	assert.Nil(t, err)
+
+	isRightFmt, err = FormatCheckers.IsFormatWithError(fakeFmtTag, "not-a-uuid")
+	assert.False(t, isRightFmt)
+	assert.NotNil(t, err)
+
+	fakeFmtTag2 := "fake2"
+	mChecker := new(mockChecker)
+	FormatCheckers.AddCheckerWithError(fakeFmtTag2, mChecker)
+
+	mChecker.On("IsFormatWithError", mock.Anything).Return(true, (ResultError)(nil)).Once()
+	isRightFmt, err = FormatCheckers.IsFormatWithError(fakeFmtTag2, "random")
+	assert.True(t, isRightFmt)
+	assert.Nil(t, err)
+	mChecker.AssertExpectations(t)
+
+	customType := "custom"
+	customErr := new(ResultErrorFields)
+	description := "override format error"
+	customErr.SetType(customType)
+	customErr.SetDescription(description)
+	mChecker.On("IsFormatWithError", mock.Anything).Return(false, customErr).Once()
+	isRightFmt, err = FormatCheckers.IsFormatWithError(fakeFmtTag2, "random2")
+	assert.False(t, isRightFmt)
+	assert.NotNil(t, err)
+	assert.Equal(t, customType, err.Type())
+	assert.Equal(t, description, err.Description())
+	mChecker.AssertExpectations(t)
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -34,6 +34,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -328,4 +331,67 @@ func TestIncorrectRef(t *testing.T) {
 
 	assert.Nil(t, s)
 	assert.Equal(t, "Object has no key 'fail'", err.Error())
+}
+
+const schemaToValidateChecker = `{
+	"properties": {
+		"foo": {
+			"type": "string",
+			"description": "Test custom format checker with custom error.",
+			"format": "foo"
+		}
+	},
+	"required": [
+		"foo"
+	]	
+}`
+
+func TestValidateWithNewChecker(t *testing.T) {
+	schemaLoader := NewStringLoader(schemaToValidateChecker)
+	s, err := NewSchema(schemaLoader)
+	require.NoError(t, err)
+
+	inpToValidateChecker := []byte(`{
+		"foo": "I want custom error plz"
+	}`)
+
+	doc := NewStringLoader(string(inpToValidateChecker))
+
+	mChecker := new(mockChecker)
+	FormatCheckers.AddCheckerWithError("foo", mChecker)
+
+	customType := "customType"
+	customErr := new(ResultErrorFields)
+	customErr.SetType(customType)
+	descriptionFmt := "wish granted lol"
+	customErr.SetDescriptionFormat(descriptionFmt)
+	mChecker.On("IsFormatWithError", mock.Anything).Return(false, customErr).Once()
+
+	res, err := s.Validate(doc)
+	require.NoError(t, err)
+	expectCustomError(t, res, customType, "wish granted lol")
+	mChecker.AssertExpectations(t)
+
+	customErr = new(ResultErrorFields)
+	customErr.SetType(customType)
+	customErr.SetDescriptionFormat("user injected value here for {{.format}}: {{.custom}}")
+	eDetails := ErrorDetails{
+		"custom": "lawlz",
+	}
+	customErr.SetDetails(eDetails)
+	mChecker.On("IsFormatWithError", mock.Anything).Return(false, customErr).Once()
+
+	res, err = s.Validate(doc)
+	require.NoError(t, err)
+	expectCustomError(t, res, customType, "user injected value here for foo: lawlz")
+	mChecker.AssertExpectations(t)
+}
+
+func expectCustomError(t *testing.T, res *Result, expType string, expDescription string) {
+	assert.False(t, res.Valid())
+	if assert.Equal(t, 1, len(res.Errors())) {
+		customErr := res.Errors()[0]
+		assert.Equal(t, expType, customErr.Type())
+		assert.Equal(t, expDescription, customErr.Description())
+	}
 }

--- a/validation.go
+++ b/validation.go
@@ -803,12 +803,17 @@ func (v *subSchema) validateString(currentSubSchema *subSchema, value interface{
 
 	// format
 	if currentSubSchema.format != "" {
-		if !FormatCheckers.IsFormat(currentSubSchema.format, stringValue) {
+		if isRightFmt, err := FormatCheckers.IsFormatWithError(currentSubSchema.format, stringValue); !isRightFmt {
+			existingDetails := err.Details()
+			if existingDetails == nil {
+				existingDetails = ErrorDetails{}
+			}
+			existingDetails["format"] = currentSubSchema.format
 			result.addInternalError(
-				new(DoesNotMatchFormatError),
+				err,
 				context,
 				value,
-				ErrorDetails{"format": currentSubSchema.format},
+				existingDetails,
 			)
 		}
 	}
@@ -899,12 +904,17 @@ func (v *subSchema) validateNumber(currentSubSchema *subSchema, value interface{
 
 	// format
 	if currentSubSchema.format != "" {
-		if !FormatCheckers.IsFormat(currentSubSchema.format, float64Value) {
+		if isRightFmt, err := FormatCheckers.IsFormatWithError(currentSubSchema.format, float64Value); !isRightFmt {
+			existingDetails := err.Details()
+			if existingDetails == nil {
+				existingDetails = ErrorDetails{}
+			}
+			existingDetails["format"] = currentSubSchema.format
 			result.addInternalError(
-				new(DoesNotMatchFormatError),
+				err,
 				context,
 				value,
-				ErrorDetails{"format": currentSubSchema.format},
+				existingDetails,
 			)
 		}
 	}


### PR DESCRIPTION
# IsFormatWithError

Updating this awesome json schema library to have better interface for FormatChecker.

## Limitations And Why

As of now, creating new custom FormatCheckers with `IsFormat` is very simplistic. Just return true or false. However, this results in the inability to modify the underlying local internal error that gets created.

```go
        if !FormatCheckers.IsFormat(currentSubSchema.format, float64Value) {
            result.addInternalError(
                new(DoesNotMatchFormatError),
                context,
                value,
                ErrorDetails{"format": currentSubSchema.format},
            )
        }
```

My rather poor workaround is massaging the error like below:

```go
    for _, jsonPkgError := range result.Errors() {
        errType := jsonPkgError.Type()
        if errType == "number_one_of" || errType == "number_all_of" {
            continue
        }

        if errType == "format" {
            customizeToWFFormatError(jsonPkgError)
...

//customizeToWFFormatError will update description / message of a "DoesNotMatchFormatError" to WF-specific. There was no easy way to integrate with 3rd party library
//as it generically returns "DoesNotMatchFormatError" in the code.
func customizeToWFFormatError(jerr gojsonschema.ResultError) {
    match := formatRegExp.FindStringSubmatch(jerr.Description())
    if len(match) == 0 {
        return
    }
    fmtTypeStr := match[1]
    fmtType := customFmtType(fmtTypeStr)

    switch fmtType {
    case poseFmt:
        updatedMsg := fmt.Sprintf("Pose ID %v does not exist!", jerr.Value())
        jerr.SetDescription(updatedMsg)
    }
}

```

This is extremely limiting since it relies on regex on the actual generic "does not match" format error string and also hardcodes what the error message should be. For example, many other reasons could go wrong:

1. Wrong JSON input is fed.
2. DB internal error.
3. Could not connect to DB.
4. Etc.

In short, only generically giving errors like "Does not match format 'blah'" is not good enough when these validation errors will be customer-facing.

## Changing IsFormat Signature

Do not fret. With a good suggestion from my colleague, *I implemented everything with backwards compatibility in mind*. Essentially introduce a new interface `FormatCheckerWithError` in file format_checkers_with_error.go. Main thing that I also needed to adjust is `FormatCheckerChain` where it now stores these new checkers.

New FormatChecker Interface:

```go
    // FormatCheckerWithError exposes a new interface for IsFormat signature. Ideally, there should be ResultError returned along with IsFmt so users can easily
    // customize the message. For now, this is a proof of concept. If met with acceptance, then we can slowly deprecate to new definition.
    FormatCheckerWithError interface {
        FormatChecker
        IsFormatWithError(input interface{}) (bool, ResultError)
    }
```

Example High-Level Usage and Proof of concept:


```go
func TestValidateWithNewChecker(t *testing.T) {
    schemaLoader := NewStringLoader(schemaToValidateChecker)
    s, err := NewSchema(schemaLoader)
    require.NoError(t, err)

    inpToValidateChecker := []byte(`{
        "foo": "I want custom error plz"
    }`)

    doc := NewStringLoader(string(inpToValidateChecker))

    mChecker := new(mockChecker)
    FormatCheckers.AddCheckerWithError("foo", mChecker)

    customType := "customType"
    customErr := new(ResultErrorFields)
    customErr.SetType(customType)
    descriptionFmt := "wish granted lol"
    customErr.SetDescriptionFormat(descriptionFmt)
    mChecker.On("IsFormatWithError", mock.Anything).Return(false, customErr).Once()

    res, err := s.Validate(doc)
    require.NoError(t, err)
    expectCustomError(t, res, customType, "wish granted lol")
    mChecker.AssertExpectations(t)

    customErr = new(ResultErrorFields)
    customErr.SetType(customType)
    customErr.SetDescriptionFormat("user injected value here for {{.format}}: {{.custom}}")
    eDetails := ErrorDetails{
        "custom": "lawlz",
    }
    customErr.SetDetails(eDetails)
    mChecker.On("IsFormatWithError", mock.Anything).Return(false, customErr).Once()

    res, err = s.Validate(doc)
    require.NoError(t, err)
    expectCustomError(t, res, customType, "user injected value here for foo: lawlz")
    mChecker.AssertExpectations(t)
}
```



How it's implemented in the background for backwards compatibility:

```go
// Add adds a FormatChecker to the FormatCheckerChain
// The name used will be the value used for the format key in your json schema
func (c *FormatCheckerChain) Add(name string, f FormatChecker) *FormatCheckerChain {
    lock.Lock()
    fmtCheckerWithErr := convertToNewChecker(f)
    c.formatters[name] = fmtCheckerWithErr
    lock.Unlock()

    return c
}
```

Then in `validation.go`, it will provide the proper `JSONContext`, `value`, etc. to user's provided custom error.
```go
	if currentSubSchema.format != "" {
		if isRightFmt, err := FormatCheckers.IsFormatWithError(currentSubSchema.format, stringValue); !isRightFmt {
			existingDetails := err.Details()
			if existingDetails == nil {
				existingDetails = ErrorDetails{}
			}
			existingDetails["format"] = currentSubSchema.format
			result.addInternalError(
				err,
				context,
				value,
				existingDetails,
			)
		}
	}
```

Thoughts?