### PR TITLE
Local Format Checker

### DIFF
--- a/format_checkers_test.go
+++ b/format_checkers_test.go
@@ -1,9 +1,20 @@
 package gojsonschema
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
+
+type mockFormatChecker struct {
+	mock.Mock
+}
+
+func (c *mockFormatChecker) IsFormat(input interface{}) bool {
+	args := c.Called(input)
+	return args.Bool(0)
+}
 
 func TestUUIDFormatCheckerIsFormat(t *testing.T) {
 	checker := UUIDFormatChecker{}

--- a/schema.go
+++ b/schema.go
@@ -51,7 +51,9 @@ func NewSchema(l JSONLoader) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.formatCheckers = new(FormatCheckerChain)
+	s.formatCheckers = &FormatCheckerChain{
+		formatters: make(map[string]FormatChecker),
+	}
 	return s, nil
 }
 

--- a/schemaLoader.go
+++ b/schemaLoader.go
@@ -157,6 +157,9 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 	d.pool.jsonLoaderFactory = rootSchema.LoaderFactory()
 	d.documentReference = ref
 	d.referencePool = newSchemaReferencePool()
+	d.formatCheckers = &FormatCheckerChain{
+		formatters: make(map[string]FormatChecker, 0),
+	}
 
 	var doc interface{}
 	if ref.String() != "" {

--- a/validation.go
+++ b/validation.go
@@ -911,7 +911,7 @@ func globalFmtCheck(currentSubSchema *subSchema, value interface{}, result *Resu
 }
 
 func applyFmtCheck(checkers *FormatCheckerChain, currentSubSchema *subSchema, value interface{}, result *Result, context *JsonContext) {
-	if checkers.IsFormat(currentSubSchema.format, value) {
+	if !checkers.IsFormat(currentSubSchema.format, value) {
 		result.addInternalError(
 			new(DoesNotMatchFormatError),
 			context,


### PR DESCRIPTION
# Local Format Checker

So another issue with this great json schema library is that it utilizes a global `FormatCheckers` for the entire JSONSchema lib.

See example code snippet below:

```go
    // FormatChecker is the interface all formatters added to FormatCheckerChain must implement
    FormatChecker interface {
        // IsFormat checks if input has the correct format and type
        IsFormat(input interface{}) bool
    }
```

## The Downside

This is particularly problematic given our case because we are allowing customers to make their own custom JSON schemas and may then need to apply different business-specific custom validations on the same format. Using one global `FormatCheckers` inextricably cause all schemas to have to use the same validators and may result in unwanted checks.

## Solution

For now, each `Schema` entity will have its own `FormatCheckerChain`. And because of the code, I had to essentially pass this `Schema` ptr to all recursive functions: not the most glamorous, but it works. See below:

```go
// Walker function to validate the json recursively against the subSchema
func (v *subSchema) validateRecursive(topSchema *Schema, currentSubSchema *subSchema, currentNode interface{}, result *Result, context *JsonContext) {
```

Note that this is the current resolution for maximal backwards compatibility and behavior:

1. First see if it can resolve locally.
2. If cannot find it, resolve globally.

The code:

```go
        if topSchema.HasFormatCheck(currentSubSchema.format) {
            applyFmtCheck(topSchema.formatCheckers, currentSubSchema, stringValue, result, context)
        } else {
            globalFmtCheck(currentSubSchema, stringValue, result, context)
        }
```

Also usage and behavior is captured in the testcase:

```go
func TestLocalValidators(t *testing.T) {
    schemaLoader := NewStringLoader(schemaToValidateChecker)

    inpToValidateChecker := []byte(`{
        "foo": "ooolala, local validators"
    }`)

    doc := NewStringLoader(string(inpToValidateChecker))

    t.Run("validate with local fmt checker", func(t *testing.T) {
        s, err := NewSchema(schemaLoader)
        require.NoError(t, err)

        mChecker := new(mockFormatChecker)
        s.AddFormatChecker("foo", mChecker)

        mChecker.On("IsFormat", mock.Anything).Return(true).Once()
        res, err := s.Validate(doc)
        require.NoError(t, err)
        assert.True(t, res.Valid())
        mChecker.AssertExpectations(t)
    })

    t.Run("local and global formatter mixed", func(t *testing.T) {
        s, err := NewSchema(schemaLoader)
        require.NoError(t, err)

        localChecker := new(mockFormatChecker)
        globalChecker := new(mockFormatChecker)
        s.AddFormatChecker("foo", localChecker)
        FormatCheckers.Add("foo", globalChecker)

        t.Run("local trumps global", func(t *testing.T) {
            localChecker.On("IsFormat", mock.Anything).Return(false).Once()
            res, err := s.Validate(doc)
            require.NoError(t, err)
            assert.False(t, res.Valid())
            localChecker.AssertExpectations(t)
            globalChecker.AssertNotCalled(t, "IsFormat", mock.Anything)
        })

        t.Run("remove local, glb formatter used", func(t *testing.T) {
            globalChecker.On("IsFormat", mock.Anything).Return(true).Once()
            s.RemoveFormatChecker("foo")
            res, err := s.Validate(doc)
            require.NoError(t, err)
            assert.True(t, res.Valid())
            globalChecker.AssertExpectations(t)
        })
    })
}
```