### PR TITLE
tests: adds test case for incorrect pattern validation.

### DIFF
--- a/testdata/draft4/pattern.json
+++ b/testdata/draft4/pattern.json
@@ -22,7 +22,7 @@
     },
     {
         "description": "pattern validation failing",
-        "schema": {"pattern": "[a-z0-9]{32,}$"},
+        "schema": {"pattern": "[a-z0-9]{32,}"},
         "tests": [
             {
                 "description": "a matching pattern is valid",

--- a/testdata/draft4/pattern.json
+++ b/testdata/draft4/pattern.json
@@ -21,6 +21,22 @@
         ]
     },
     {
+        "description": "pattern validation failing",
+        "schema": {"pattern": "[a-z0-9]{32,}$"},
+        "tests": [
+            {
+                "description": "a matching pattern is valid",
+                "data": "7f46165474d11ee5836777d85df2cdab$",
+                "valid": true
+            },
+            {
+                "description": "a matching pattern is valid",
+                "data": "7$f46165474d11ee5836777d85df2cdab",
+                "valid": false
+            }
+        ]
+    },
+    {
         "description": "pattern is not anchored",
         "schema": {"pattern": "a+"},
         "tests": [


### PR DESCRIPTION
This PR test case shows a test case where a string with pattern `[a-z0-9]{32,}` is matched by `7f46165474d11ee5836777d85df2cdab$` and not by `7$f46165474d11ee5836777d85df2cdab`.

Ping @marc-gr