### PR TITLE
add check for schema map[string]interface{} asssertion

### DIFF
--- a/draft.go
+++ b/draft.go
@@ -94,12 +94,7 @@ func parseSchemaURL(documentNode interface{}) (string, *Draft, error) {
 	}
 
 	if !isKind(documentNode, reflect.Map) {
-		return "", nil, errors.New(formatErrorDescription(
-			Locale.ParseError(),
-			ErrorDetails{
-				"expected": STRING_SCHEMA,
-			},
-		))
+		return "", nil, errors.New("schema is invalid")
 	}
 
 	m := documentNode.(map[string]interface{})

--- a/schemaLoader_test.go
+++ b/schemaLoader_test.go
@@ -172,5 +172,5 @@ func TestParseSchemaURL_NotMap(t *testing.T) {
 	_, err := NewSchema(sl)
 	//THEN
 	require.Error(t, err)
-	assert.EqualError(t, err, "Expected: valid schema, given: Invalid JSON")
+	assert.EqualError(t, err, "schema is invalid")
 }


### PR DESCRIPTION
When you use `GoLoader` and put something that is not `map[string]interface{}` the library panic on nil value, because in `draft.go`, line 95 `m := documentNode.(map[string]interface{})`, assertion is not checked.
[our issue](https://github.com/kyma-incubator/compass/issues/256)