### PR TITLE
Discriminator proof-of-concept

### DIFF
--- a/subSchema.go
+++ b/subSchema.go
@@ -27,9 +27,10 @@
 package gojsonschema
 
 import (
-	"github.com/xeipuuv/gojsonreference"
 	"math/big"
 	"regexp"
+
+	"github.com/xeipuuv/gojsonreference"
 )
 
 // Constants
@@ -46,6 +47,7 @@ const (
 	KEY_PROPERTIES            = "properties"
 	KEY_PATTERN_PROPERTIES    = "patternProperties"
 	KEY_ADDITIONAL_PROPERTIES = "additionalProperties"
+	KEY_PROPERTY_NAME         = "propertyName"
 	KEY_PROPERTY_NAMES        = "propertyNames"
 	KEY_DEFINITIONS           = "definitions"
 	KEY_MULTIPLE_OF           = "multipleOf"
@@ -74,6 +76,8 @@ const (
 	KEY_IF                    = "if"
 	KEY_THEN                  = "then"
 	KEY_ELSE                  = "else"
+	KEY_DISCRIMINATOR         = "discriminator"
+	KEY_MAPPING               = "mapping"
 )
 
 type subSchema struct {
@@ -146,4 +150,8 @@ type subSchema struct {
 	_if   *subSchema // if/else are golang keywords
 	_then *subSchema
 	_else *subSchema
+
+	// validation : discriminator
+	discriminatorProperty string
+	discriminatorMapping  map[string]*subSchema
 }

--- a/testdata/draft6/discriminator.json
+++ b/testdata/draft6/discriminator.json
@@ -1,0 +1,86 @@
+[
+    {
+        "description": "discriminator",
+        "schema": {
+            "id": "https://cody.ebberson.com/",
+            "discriminator": {
+                "propertyName": "resourceType",
+                "mapping": {
+                    "bar": "#/definitions/bar",
+                    "foo": "#/definitions/foo"
+                }
+            },
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/bar"
+                },
+                {
+                    "$ref": "#/definitions/foo"
+                }
+            ],
+            "definitions": {
+                "bar": {
+                    "properties": {
+                        "resourceType": {
+                            "const": "bar"
+                        },
+                        "valueInteger": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "resourceType",
+                        "valueInteger"
+                    ]
+                },
+                "foo": {
+                    "properties": {
+                        "resourceType": {
+                            "const": "foo"
+                        },
+                        "valueString": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "resourceType",
+                        "valueString"
+                    ]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "first discriminator valid",
+                "data": {
+                    "resourceType": "bar",
+                    "valueInteger": 2
+                },
+                "valid": true
+            },
+            {
+                "description": "second discriminator valid",
+                "data": {
+                    "resourceType": "foo",
+                    "valueString": "baz"
+                },
+                "valid": true
+            },
+            {
+                "description": "no discriminator match (unknown resourceType)",
+                "data": {
+                    "resourceType": "baz",
+                    "valueString": "baz"
+                },
+                "valid": false
+            },
+            {
+                "description": "no discriminator match (missing required property)",
+                "data": {
+                    "resourceType": "foo"
+                },
+                "valid": false
+            }
+        ]
+    }
+]


### PR DESCRIPTION
_Note: test coverage and error handling are incomplete -- I wanted to run this by maintainers first to see if it's worth it._

This PR introduces basic support for `discriminator` as a performance optimization when validating large `oneOf` schemas.

Admittedly, `discriminator` is not officially part of JSONSchema.  However, it is used by Swagger and OpenAPI, and therefore is used by many popular open source libraries.

For my particular use case, this change decreased validation time from 80 seconds to 0.13 seconds (~600x speedup).  See full details here: https://github.com/codyebberson/gojsonschema-fhir-benchmark

Additionally, using `discriminator` would enable more informative error messages.  Currently, `oneOf` error messages are very hit or miss.  By using `discriminator`, you would know exactly which subSchema to use for errors.

Let me know if this is something that you would consider integrating.  I would be happy to polish this up, add better error handling, add more tests, and improve the error messages.