### PR TITLE
Speed up validation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -323,7 +323,6 @@ func newError(err ResultError, context *JsonContext, value interface{}, locale l
 		details["context"] = context.String()
 	}
 
-	err.SetDescription(formatErrorDescription(err.DescriptionFormat(), details))
 }
 
 // formatErrorDescription takes a string in the default text/template

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/xeipuuv/gojsonschema
 
-go 1.14
-
 require (
 	github.com/stretchr/testify v1.3.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/xeipuuv/gojsonschema
 
+go 1.14
+
 require (
 	github.com/stretchr/testify v1.3.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect

--- a/result.go
+++ b/result.go
@@ -188,6 +188,9 @@ func (v *Result) Valid() bool {
 
 // Errors returns the errors that were found
 func (v *Result) Errors() []ResultError {
+	for _, err := range v.errors {
+		err.SetDescription(formatErrorDescription(err.DescriptionFormat(), err.Details()))
+	}
 	return v.errors
 }
 


### PR DESCRIPTION
All I did is only generating the errors on demand. Tests are passing. 

We often create errors without actually failing the validation. Whenever that happens we still format error messages that nobody will ever see. So I moved that to the consumer. 