### PR TITLE
Pluggable Regexpr Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,6 @@ err := sl.AddSchemas(gojsonschema.NewStringLoader(`{
     "multipleOf" : true
 }`))
  ```
-```
- ```
 
 Errors returned by meta-schema validation are more readable and contain more information, which helps significantly if you are developing a schema.
 

--- a/README.md
+++ b/README.md
@@ -465,13 +465,27 @@ The regular expression library can be changed by implementing [RegexpProvider](r
 ```go
 import "github.com/dlclark/regexp2"
 
-type Regexp2Provider struct {
+type regexp2Provider struct{}
+
+type regexp2CompiledRegexp struct {
+	compiled *regexp2.Regexp
 }
 
-func (Regexp2Provider) Compile(expr string) (CompiledRegexp, error) {
-	return regexp2.Compile(expr)
+func (c regexp2CompiledRegexp) MatchString(s string) bool {
+	if matched, err := c.compiled.MatchString(s); err != nil {
+		return false
+	} else {
+		return matched
+	}
 }
 
+func (regexp2Provider) Compile(expr string) (gojsonschema.CompiledRegexp, error) {
+	if compiled, err := regexp2.Compile(expr, 0); err != nil {
+		return nil, err
+	} else {
+		return regexp2CompiledRegexp{compiled}, nil
+	}
+}
 sl := gojsonschema.NewSchemaLoader()
 sl.RegexpProvider = Regexp2Provider{}
 loader := gojsonschema.NewStringLoader(`{ "type" : "string", "pattern": "(?=foo)bar" }`)

--- a/regexpProvider.go
+++ b/regexpProvider.go
@@ -1,0 +1,32 @@
+package gojsonschema
+
+import (
+	"regexp"
+)
+
+var (
+	defaultRegexProvider = golangRegexpProvider{}
+)
+
+// RegexpProvider An interface to a regex implementation
+type RegexpProvider interface {
+	// Compile Compiles an expression and returns a CompiledRegexp
+	Compile(expr string) (CompiledRegexp, error)
+}
+
+// CompiledRegexp A compiled expression
+type CompiledRegexp interface {
+	// MatchString Tests if the string matches the compiled expression
+	MatchString(s string) bool
+}
+
+type golangRegexpProvider struct {
+}
+
+func (golangRegexpProvider) Compile(expr string) (CompiledRegexp, error) {
+	return regexp.Compile(expr)
+}
+
+func getDefaultRegexpProvider() RegexpProvider {
+	return defaultRegexProvider
+}

--- a/regexpProvider_test.go
+++ b/regexpProvider_test.go
@@ -1,0 +1,81 @@
+// Copyright 2018 johandorland ( https://github.com/johandorland )
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gojsonschema
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type customCompiled struct {
+	pattern           *regexp.Regexp
+	expr              string
+	matchStringCalled int
+}
+
+func (cc *customCompiled) MatchString(s string) bool {
+	cc.matchStringCalled++
+	return cc.pattern.MatchString(s)
+}
+
+type customRegexpProvider struct {
+	compileCalled  int
+	compiledRegexp map[string]*customCompiled
+}
+
+func (c *customRegexpProvider) Compile(expr string) (CompiledRegexp, error) {
+	c.compileCalled++
+	pattern, err := regexp.Compile(expr)
+	if err != nil {
+		return nil, err
+	}
+	cc := &customCompiled{
+		pattern: pattern,
+		expr:    expr,
+	}
+	if c.compiledRegexp == nil {
+		c.compiledRegexp = make(map[string]*customCompiled)
+	}
+	c.compiledRegexp[expr] = cc
+	return cc, nil
+}
+
+func TestCustomRegexpProvider(t *testing.T) {
+	// Verify that the RegexpProvider is used
+	loader := NewStringLoader(`{
+			"patternProperties": {
+				"f.*o": {"type": "integer"},
+				"b.*r": {"type": "string", "pattern": "^a*$"}
+			}
+		}`)
+
+	sl := NewSchemaLoader()
+	customRegexpProvider := &customRegexpProvider{}
+	sl.RegexpProvider = customRegexpProvider
+	d, err := sl.Compile(loader)
+	assert.Nil(t, err)
+	assert.NotNil(t, d.regexp)
+
+	loader = NewStringLoader(`{"foo": 1, "foooooo" : 2, "bar": "a", "baaaar": "aaaa"}`)
+	r, err := d.Validate(loader)
+	assert.Nil(t, err)
+	assert.Empty(t, r.errors)
+	assert.Equal(t, 3, customRegexpProvider.compileCalled)
+	assert.Equal(t, 4, customRegexpProvider.compiledRegexp["f.*o"].matchStringCalled)
+	assert.Equal(t, 4, customRegexpProvider.compiledRegexp["b.*r"].matchStringCalled)
+	assert.Equal(t, 2, customRegexpProvider.compiledRegexp["^a*$"].matchStringCalled)
+}

--- a/schemaLoader.go
+++ b/schemaLoader.go
@@ -23,10 +23,11 @@ import (
 
 // SchemaLoader is used to load schemas
 type SchemaLoader struct {
-	pool       *schemaPool
-	AutoDetect bool
-	Validate   bool
-	Draft      Draft
+	pool           *schemaPool
+	AutoDetect     bool
+	Validate       bool
+	Draft          Draft
+	RegexpProvider RegexpProvider
 }
 
 // NewSchemaLoader creates a new NewSchemaLoader
@@ -153,6 +154,9 @@ func (sl *SchemaLoader) Compile(rootSchema JSONLoader) (*Schema, error) {
 	}
 
 	d := Schema{}
+	if d.regexp = sl.RegexpProvider; d.regexp == nil {
+		d.regexp = getDefaultRegexpProvider()
+	}
 	d.pool = sl.pool
 	d.pool.jsonLoaderFactory = rootSchema.LoaderFactory()
 	d.documentReference = ref

--- a/schemaLoader_test.go
+++ b/schemaLoader_test.go
@@ -15,8 +15,9 @@
 package gojsonschema
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -173,4 +174,23 @@ func TestParseSchemaURL_NotMap(t *testing.T) {
 	//THEN
 	require.Error(t, err)
 	assert.EqualError(t, err, "schema is invalid")
+}
+
+func TestDefaultRegexpProvider(t *testing.T) {
+	//Verify that when no RegexpProvider is set, the default Regexp Provider is used
+	loader := NewStringLoader(`{
+		"patternProperties": {
+			"f.*o": {"type": "integer"},
+			"b.*r": {"type": "string", "pattern": "^a*$"}
+		}
+	}`)
+
+	d, err := NewSchema(loader)
+	assert.Nil(t, err)
+	assert.NotNil(t, d.regexp)
+
+	loader = NewStringLoader(`{"foo": 1, "foooooo" : 2, "bar": "a", "baaaar": "aaaa"}`)
+	r, err := d.Validate(loader)
+	assert.Nil(t, err)
+	assert.Empty(t, r.errors)
 }

--- a/subSchema.go
+++ b/subSchema.go
@@ -27,9 +27,9 @@
 package gojsonschema
 
 import (
-	"github.com/xeipuuv/gojsonreference"
 	"math/big"
-	"regexp"
+
+	"github.com/xeipuuv/gojsonreference"
 )
 
 // Constants
@@ -76,6 +76,11 @@ const (
 	KEY_ELSE                  = "else"
 )
 
+type patternProperties struct {
+	schema  *subSchema
+	pattern CompiledRegexp
+}
+
 type subSchema struct {
 	draft *Draft
 
@@ -113,7 +118,7 @@ type subSchema struct {
 	// validation : string
 	minLength *int
 	maxLength *int
-	pattern   *regexp.Regexp
+	pattern   CompiledRegexp
 	format    string
 
 	// validation : object
@@ -123,7 +128,7 @@ type subSchema struct {
 
 	dependencies         map[string]interface{}
 	additionalProperties interface{}
-	patternProperties    map[string]*subSchema
+	patternProperties    map[string]*patternProperties
 	propertyNames        *subSchema
 
 	// validation : array

--- a/validation.go
+++ b/validation.go
@@ -29,7 +29,6 @@ import (
 	"encoding/json"
 	"math/big"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -687,11 +686,11 @@ func (v *subSchema) validatePatternProperty(currentSubSchema *subSchema, key str
 
 	validated := false
 
-	for pk, pv := range currentSubSchema.patternProperties {
-		if matches, _ := regexp.MatchString(pk, key); matches {
+	for _, pp := range currentSubSchema.patternProperties {
+		if matches := pp.pattern.MatchString(key); matches {
 			validated = true
 			subContext := NewJsonContext(key, context)
-			validationResult := pv.subValidateWithContext(value, subContext)
+			validationResult := pp.schema.subValidateWithContext(value, subContext)
 			result.mergeErrors(validationResult)
 		}
 	}


### PR DESCRIPTION
Adding support for plugging in different regular expression engines.

Anything that implements the `RegexpProvider` interface can be used in to do all the regexp matching. I'm not sold on the name of the interface or the name of the property in `SchemaLoader`, so I'm happy to take suggestions on the name.

I added new tests for the functionality and verified that all the line I changed have test coverage.

Let me know what you think.

P.S. Sorry there is a little bit of noise in `README.md` as my editor striped trailing whitespace. 