### PR TITLE
Fix syntax error in meta-schema validation example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The following example will produce an error as `multipleOf` must be a number. If
 sl := gojsonschema.NewSchemaLoader()
 sl.Validate = true
 err := sl.AddSchemas(gojsonschema.NewStringLoader(`{
-     $id" : "http://some_host.com/invalid.json",
+     "$id" : "http://some_host.com/invalid.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "multipleOf" : true
 }`))


### PR DESCRIPTION
The previous snippet resulted in the error:
```
invalid character '$' looking for beginning of object key string
```

Rather than the intended error:
```
multipleOf: Invalid type. Expected: number, given: boolean
```