### PR TITLE
Fix email validation

### DIFF
--- a/format_checkers.go
+++ b/format_checkers.go
@@ -194,8 +194,12 @@ func (f EmailFormatChecker) IsFormat(input interface{}) bool {
 		return true
 	}
 
-	_, err := mail.ParseAddress(asString)
-	return err == nil
+	res, err := mail.ParseAddress(asString)
+	if err != nil || res.Address != asString {
+		return false
+	}
+
+	return true
 }
 
 // IsFormat checks if input is a correctly formatted IPv4-address

--- a/testdata/draft4/optional/format.json
+++ b/testdata/draft4/optional/format.json
@@ -134,6 +134,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": " joe.bloggs@example.com",
+                "valid": false
             }
         ]
     },

--- a/testdata/draft6/optional/format.json
+++ b/testdata/draft6/optional/format.json
@@ -203,6 +203,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": " joe.bloggs@example.com",
+                "valid": false
             }
         ]
     },

--- a/testdata/draft7/optional/format/email.json
+++ b/testdata/draft7/optional/format/email.json
@@ -12,6 +12,11 @@
                 "description": "an invalid e-mail address",
                 "data": "2962",
                 "valid": false
+            },
+            {
+                "description": "an invalid e-mail address",
+                "data": " joe.bloggs@example.com",
+                "valid": false
             }
         ]
     }


### PR DESCRIPTION
mail.ParseAddress return an reformated email if the format is not really an email (with a space after of before for example).
A check was added to compare the input and the output from mail.ParseAddress.