### PR TITLE
Add `func (*FormatCheckerChain).Empty()`

### DIFF
--- a/format_checkers.go
+++ b/format_checkers.go
@@ -144,6 +144,13 @@ var (
 	lock = new(sync.RWMutex)
 )
 
+// Empty resets the FormatCheckerChain
+func (c *FormatCheckerChain) Empty() {
+	lock.Lock()
+	c.formatters = make(map[string]FormatChecker)
+	lock.Unlock()
+}
+
 // Add adds a FormatChecker to the FormatCheckerChain
 // The name used will be the value used for the format key in your json schema
 func (c *FormatCheckerChain) Add(name string, f FormatChecker) *FormatCheckerChain {


### PR DESCRIPTION
Actually I lied in my example code in https://github.com/xeipuuv/gojsonschema/pull/325 as it fails with `panic: assignment to entry in nil map`.